### PR TITLE
feat(input): キー解放を配り、ポインタ押下/解放に修飾キーを載せる (#1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,52 @@
 
 ## [Unreleased]
 
+修飾キーつきのポインタ操作（⇧+クリック = 選択に足す／外す、⌥+ドラッグ = 複製）が
+`DeclarativeApp` の上で書けるようになった版。値は runtime が既に握っていたのに、
+façade が落としていた 2 箇所を塞ぐ。
+
+同じ組織の別アプリ（bamiri）は winit のイベントループを自前で持っているので同じことが
+できていた。差は「情報が無い」ことではなく「`DeclarativeApp` に乗ると届かない」ことだった。
+
+### Fixed
+- **キーの解放がアプリに届かない**
+  ([#1](https://github.com/Mutafika/sabitori/issues/1))。`DeclarativeApp` の
+  `WindowEvent::KeyboardInput` が `ElementState::Pressed` で絞っていたため、
+  `InputEvent::KeyInput { pressed: false, .. }` が一度も発行されていなかった。
+
+  ⇧単独の押下は `Key::Shift` として届くのに離したことが分からないので、アプリ側で
+  「押しっぱなし」を保持すると**二度と落ちない**。⇧を押している間だけオルソ、のような
+  モードが成立しなかった。押下・解放の両方を転送するようにした。
+
+  副作用（コピー・選択解除・フォーカス移動・文字入力）は従来どおり**押下でだけ**走る。
+  解放でも走らせると、⇧を離しただけで選択が消える別のバグになる。
+
+### Added
+- **`InputEvent::PointerPressed` / `PointerReleased` に `modifiers` が載った**
+  ([#1](https://github.com/Mutafika/sabitori/issues/1))。押した**瞬間**に握られていた
+  修飾キーが読める。
+
+  ```rust
+  InputEvent::PointerPressed { position, modifiers, .. } => {
+      if modifiers.shift { self.toggle_at(*position) } else { self.select_at(*position) }
+  }
+  ```
+
+  押下時の状態が無いと、アプリは `KeyInput` を自前で追って状態機械を持つしかなく、
+  それは上の解放イベントが来て初めて成立する。ポインタ操作にはこちらが素直。
+
+  `PointerReleased` の値は押下時と違いうる（押してから⇧を足す／離す）ので、
+  `PointerPressed` の値を使い回さないこと。3 ランタイム（`DeclarativeApp` /
+  `SceneApp` / `SabitoriApp`）とも、既に保持している修飾キー状態から埋めている。
+
+  ⚠️ **破壊的変更**: この 2 variant を**構築**しているコード、および全フィールドを
+  列挙して `match` しているコードは修正が要る（`..` で受けているなら無傷）。
+
+### Changed
+- `DeclarativeApp` のキーボード処理を `AppState::handle_key_input` に切り出した。
+  winit 依存が `WindowEvent::KeyboardInput` の数行だけになり、押下／解放の
+  ルーティングをヘッドレスのテストで検査できるようになった。
+
 ## [0.3.13] - 2026-08-07
 
 **下流が v0.3.12 に対してビルドできない**のを直した緊急版。`0.2` 系では通っていた

--- a/crates/sabitori-input/src/lib.rs
+++ b/crates/sabitori-input/src/lib.rs
@@ -103,6 +103,11 @@ pub enum InputEvent {
         kind: PointerKind,
         position: Point,
         button: Option<MouseButton>,
+        /// 押した**瞬間**に握られていた修飾キー。⇧+クリック = 選択に足す／外す、
+        /// ⌥+ドラッグ = 複製、のような修飾つきポインタ操作は、押下時の状態が
+        /// 分からないと書けない。`KeyInput` を自前で追って状態を持つ手もあるが、
+        /// 値は runtime が既に握っているので載せて配る方が素直。
+        modifiers: Modifiers,
     },
     /// Pointer released (mouse button up, touch end, pen up).
     PointerReleased {
@@ -110,6 +115,9 @@ pub enum InputEvent {
         kind: PointerKind,
         position: Point,
         button: Option<MouseButton>,
+        /// 離した瞬間の修飾キー。押下時と違う場合がある（押してから⇧を足す/離す）
+        /// ので、`PointerPressed` の値をそのまま使い回さないこと。
+        modifiers: Modifiers,
     },
     /// Pointer interaction cancelled (system gesture, touch cancelled by OS, etc).
     PointerCancelled {

--- a/crates/sabitori-window/src/lib.rs
+++ b/crates/sabitori-window/src/lib.rs
@@ -190,6 +190,7 @@ impl<A: SabitoriApp> ApplicationHandler for AppState<A> {
                             kind: PointerKind::Mouse,
                             position: pos,
                             button: Some(btn),
+                            modifiers: keymap::modifiers_from_winit(self.winit_modifiers),
                         });
                     }
                     ElementState::Released => {
@@ -213,6 +214,7 @@ impl<A: SabitoriApp> ApplicationHandler for AppState<A> {
                             kind: PointerKind::Mouse,
                             position: pos,
                             button: Some(btn),
+                            modifiers: keymap::modifiers_from_winit(self.winit_modifiers),
                         });
                         if btn == MouseButton::Left
                             && self.primary_input == PrimaryInput::Mouse
@@ -252,6 +254,7 @@ impl<A: SabitoriApp> ApplicationHandler for AppState<A> {
                             kind: PointerKind::Touch,
                             position: pos,
                             button: None,
+                            modifiers: keymap::modifiers_from_winit(self.winit_modifiers),
                         });
                     }
                     TouchPhase::Moved => {
@@ -274,6 +277,7 @@ impl<A: SabitoriApp> ApplicationHandler for AppState<A> {
                             kind: PointerKind::Touch,
                             position: pos,
                             button: None,
+                            modifiers: keymap::modifiers_from_winit(self.winit_modifiers),
                         });
                         // Release ownership when the last finger lifts.
                         if self.primary_input == PrimaryInput::Touch
@@ -762,6 +766,7 @@ impl<A: SabitoriApp> EmbeddedRunner<A> {
                 kind,
                 position,
                 button,
+                ..
             } => {
                 let is_primary =
                     button == Some(MouseButton::Left) || kind != PointerKind::Mouse;
@@ -785,6 +790,7 @@ impl<A: SabitoriApp> EmbeddedRunner<A> {
                 kind: _,
                 position,
                 button,
+                ..
             } => {
                 let is_primary = button == Some(MouseButton::Left) || button.is_none();
                 if !is_primary {

--- a/crates/sabitori/src/declarative.rs
+++ b/crates/sabitori/src/declarative.rs
@@ -893,6 +893,7 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
                     kind: PointerKind::Mouse,
                     position: sabitori_core::Point::new(self.mouse_x, self.mouse_y),
                     button: Some(InputMouseButton::Left),
+                    modifiers: self.modifiers,
                 });
                 if let Some(ref build) = self.last_build {
                     let pt = sabitori_core::Point::new(self.mouse_x, self.mouse_y);
@@ -992,6 +993,7 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
                     kind: PointerKind::Mouse,
                     position: sabitori_core::Point::new(self.mouse_x, self.mouse_y),
                     button: Some(InputMouseButton::Left),
+                    modifiers: self.modifiers,
                 });
                 // text selection drag 終了。 selection 自体は維持して Cmd+C を待つ。
                 self.selecting = false;
@@ -1067,12 +1069,14 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
                         kind: PointerKind::Mouse,
                         position,
                         button: Some(InputMouseButton::Middle),
+                        modifiers: self.modifiers,
                     },
                     winit::event::ElementState::Released => InputEvent::PointerReleased {
                         id: MOUSE_POINTER_ID,
                         kind: PointerKind::Mouse,
                         position,
                         button: Some(InputMouseButton::Middle),
+                        modifiers: self.modifiers,
                     },
                 };
                 self.app.on_input(&ev);
@@ -1130,6 +1134,7 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
                             kind: PointerKind::Touch,
                             position: pos,
                             button: None,
+                            modifiers: self.modifiers,
                         });
                     }
                     winit::event::TouchPhase::Moved => {
@@ -1147,6 +1152,7 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
                             kind: PointerKind::Touch,
                             position: pos,
                             button: None,
+                            modifiers: self.modifiers,
                         });
                     }
                     winit::event::TouchPhase::Cancelled => {
@@ -1412,106 +1418,18 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
                 };
             }
             WindowEvent::KeyboardInput { event, .. } => {
-                if event.state == winit::event::ElementState::Pressed {
-                    // winit → Key の変換は sabitori_window::keymap に集約している
-                    // （3 ランタイム共通）。対応が無い名前付きキーは Other として
-                    // 届ける — 修飾キー単独押下を「何か押された」として観測する
-                    // 既存の挙動（下の選択解除ロジックが Other に依存）を保つため。
-                    let key = sabitori_window::keymap::key_from_winit(&event.logical_key)
-                        .unwrap_or(Key::Other);
-                    // Cmd+C (macOS) / Ctrl+C (other): copy selected text to clipboard.
-                    // 文字選択中 (= self.selection が Some) ならグローバル捕捉して
-                    // focused element の input route には流さない。 macOS では meta
-                    // (Cmd) を見る、 他 platform は ctrl。
-                    let copy_modifier = if cfg!(target_os = "macos") {
-                        self.modifiers.meta
-                    } else {
-                        self.modifiers.ctrl
-                    };
-                    let is_copy = key == Key::C && copy_modifier;
-                    if is_copy {
-                        if let Some(text) = self.selected_text() {
-                            #[cfg(target_os = "macos")]
-                            crate::macos_drag::copy_text_to_clipboard(&text);
-                            #[cfg(not(target_os = "macos"))]
-                            { let _ = text; /* TODO: linux/wasm clipboard */ }
-                        }
-                    }
-                    // Any key other than the copy shortcut dismisses the
-                    // selection — typing, pasting (Cmd+V), Enter, navigation all
-                    // end it, like a terminal/editor. Without this the highlight
-                    // persists after a paste and re-paints over the new text (it
-                    // looks like you're stuck in "selection mode"). Bare modifier
-                    // presses map to `Key::Other`, which must NOT clear: holding
-                    // Cmd to then press C would otherwise wipe the selection
-                    // before the copy above can read it.
-                    if !is_copy && key != Key::Other {
-                        self.selection = None;
-                    }
-                    // Escape clears focus
-                    if key == Key::Escape {
-                        self.focused_id = None;
-                    }
-                    // Tab / Shift+Tab moves focus between focusable elements
-                    if key == Key::Tab {
-                        if let Some(ref build) = self.last_build {
-                            let focusable_ids: Vec<String> = build.hit_regions.iter()
-                                .rev() // hit_regions are front-to-back; reverse for document order
-                                .filter(|r| r.focusable && r.id.is_some())
-                                .map(|r| r.id.clone().unwrap())
-                                .collect();
-                            if !focusable_ids.is_empty() {
-                                let current_idx = self.focused_id.as_ref()
-                                    .and_then(|id| focusable_ids.iter().position(|f| f == id));
-                                let next = if self.modifiers.shift {
-                                    // Shift+Tab: go backwards
-                                    match current_idx {
-                                        Some(0) | None => focusable_ids.len() - 1,
-                                        Some(i) => i - 1,
-                                    }
-                                } else {
-                                    // Tab: go forwards
-                                    match current_idx {
-                                        Some(i) if i + 1 < focusable_ids.len() => i + 1,
-                                        _ => 0,
-                                    }
-                                };
-                                self.focused_id = Some(focusable_ids[next].clone());
-                            }
-                        }
-                    }
-                    // Escape / Tab moved focus → refresh the capture snapshot
-                    // before the event reaches the app.
-                    if key == Key::Escape || key == Key::Tab {
-                        self.push_ui_capture();
-                    }
-                    // Route to focused element first, then to app
-                    let key_event = InputEvent::KeyInput {
-                        key,
-                        pressed: true,
-                        modifiers: self.modifiers,
-                    };
-                    let handled_by_focus = if key != Key::Tab && key != Key::Escape {
-                        if let Some(ref id) = self.focused_id {
-                            self.app.on_focused_input(id, &key_event)
-                        } else { false }
-                    } else { false };
-                    if !handled_by_focus {
-                        self.app.on_input(&key_event);
-                    }
-                    // テキスト入力として送るべき文字の判定（制御文字の除去、Cmd 押下時の
-                    // 抑制、Alt を通すか等）は keymap::char_inputs に集約している。
-                    // ここはルーティングだけ。
-                    for ch in sabitori_window::keymap::char_inputs(&event, self.modifiers) {
-                        let char_event = InputEvent::CharInput(ch);
-                        let handled = if let Some(ref id) = self.focused_id {
-                            self.app.on_focused_input(id, &char_event)
-                        } else { false };
-                        if !handled {
-                            self.app.on_input(&char_event);
-                        }
-                    }
-                }
+                // winit → Key の変換は sabitori_window::keymap に集約している
+                // （3 ランタイム共通）。対応が無い名前付きキーは Other として
+                // 届ける — 修飾キー単独押下を「何か押された」として観測する
+                // 既存の挙動（選択解除ロジックが Other に依存）を保つため。
+                let key = sabitori_window::keymap::key_from_winit(&event.logical_key)
+                    .unwrap_or(Key::Other);
+                let pressed = event.state == winit::event::ElementState::Pressed;
+                // テキスト入力として送るべき文字の判定（制御文字の除去、Cmd 押下時の
+                // 抑制、Alt を通すか等）は keymap::char_inputs に集約している。
+                // 解放時は空を返すので、本体側の分岐と二重には効かない。
+                let chars = sabitori_window::keymap::char_inputs(&event, self.modifiers);
+                self.handle_key_input(key, pressed, chars);
             }
             WindowEvent::Ime(ime_event) => {
                 let event = match &ime_event {
@@ -2186,6 +2104,119 @@ impl<A: DeclarativeApp> AppState<A> {
         }
     }
 
+    /// `WindowEvent::KeyboardInput` の本体を winit から剥がしたもの。 `chars` は
+    /// `keymap::char_inputs` が解決済みの文字（解放時は空）。
+    ///
+    /// 押下・解放の**両方**で呼ばれ、`KeyInput` もその両方を発行する。押下だけを
+    /// 配っていた頃は、⇧の押下は届くのに解放が来ないので、アプリ側で「押しっぱなし」
+    /// を保持すると二度と落ちなかった（⇧+ドラッグ = 選択に足す、のような修飾つき
+    /// 操作が書けない）。副作用は `if pressed` の中に閉じてある。
+    fn handle_key_input(&mut self, key: Key, pressed: bool, chars: Vec<char>) {
+        // 副作用（コピー・選択解除・フォーカス移動・文字入力）は押下でだけ
+        // 起こす。解放でも走らせると、⇧を離しただけで選択が消えるといった
+        // 挙動になる。アプリへの KeyInput 転送だけが押下・解放の両方。
+        if pressed {
+            // Cmd+C (macOS) / Ctrl+C (other): copy selected text to clipboard.
+            // 文字選択中 (= self.selection が Some) ならグローバル捕捉して
+            // focused element の input route には流さない。 macOS では meta
+            // (Cmd) を見る、 他 platform は ctrl。
+            let copy_modifier = if cfg!(target_os = "macos") {
+                self.modifiers.meta
+            } else {
+                self.modifiers.ctrl
+            };
+            let is_copy = key == Key::C && copy_modifier;
+            if is_copy {
+                if let Some(text) = self.selected_text() {
+                    #[cfg(target_os = "macos")]
+                    crate::macos_drag::copy_text_to_clipboard(&text);
+                    #[cfg(not(target_os = "macos"))]
+                    { let _ = text; /* TODO: linux/wasm clipboard */ }
+                }
+            }
+            // Any key other than the copy shortcut dismisses the
+            // selection — typing, pasting (Cmd+V), Enter, navigation all
+            // end it, like a terminal/editor. Without this the highlight
+            // persists after a paste and re-paints over the new text (it
+            // looks like you're stuck in "selection mode"). Bare modifier
+            // presses map to `Key::Other`, which must NOT clear: holding
+            // Cmd to then press C would otherwise wipe the selection
+            // before the copy above can read it.
+            if !is_copy && key != Key::Other {
+                self.selection = None;
+            }
+            // Escape clears focus
+            if key == Key::Escape {
+                self.focused_id = None;
+            }
+            // Tab / Shift+Tab moves focus between focusable elements
+            if key == Key::Tab {
+                if let Some(ref build) = self.last_build {
+                    let focusable_ids: Vec<String> = build.hit_regions.iter()
+                        .rev() // hit_regions are front-to-back; reverse for document order
+                        .filter(|r| r.focusable && r.id.is_some())
+                        .map(|r| r.id.clone().unwrap())
+                        .collect();
+                    if !focusable_ids.is_empty() {
+                        let current_idx = self.focused_id.as_ref()
+                            .and_then(|id| focusable_ids.iter().position(|f| f == id));
+                        let next = if self.modifiers.shift {
+                            // Shift+Tab: go backwards
+                            match current_idx {
+                                Some(0) | None => focusable_ids.len() - 1,
+                                Some(i) => i - 1,
+                            }
+                        } else {
+                            // Tab: go forwards
+                            match current_idx {
+                                Some(i) if i + 1 < focusable_ids.len() => i + 1,
+                                _ => 0,
+                            }
+                        };
+                        self.focused_id = Some(focusable_ids[next].clone());
+                    }
+                }
+            }
+            // Escape / Tab moved focus → refresh the capture snapshot
+            // before the event reaches the app.
+            if key == Key::Escape || key == Key::Tab {
+                self.push_ui_capture();
+            }
+        }
+        // Route to focused element first, then to app.
+        //
+        // 押下・解放の**両方**を発行する。押下だけを配っていた頃は、
+        // ⇧の押下は届くのに解放が来ないので、アプリ側で「押しっぱなし」を
+        // 保持すると二度と落ちなかった（⇧+ドラッグ = 選択に足す、のような
+        // 修飾つき操作が作れない）。副作用は上の `if pressed` に閉じてある。
+        let key_event = InputEvent::KeyInput {
+            key,
+            pressed,
+            modifiers: self.modifiers,
+        };
+        let handled_by_focus = if key != Key::Tab && key != Key::Escape {
+            if let Some(ref id) = self.focused_id {
+                self.app.on_focused_input(id, &key_event)
+            } else { false }
+        } else { false };
+        if !handled_by_focus {
+            self.app.on_input(&key_event);
+        }
+        if pressed {
+            // テキスト入力として送るべき文字の判定（制御文字の除去、Cmd 押下時の
+            // 抑制、Alt を通すか等）は keymap::char_inputs に集約している。
+            // ここはルーティングだけ。
+            for ch in chars {
+                let char_event = InputEvent::CharInput(ch);
+                let handled = if let Some(ref id) = self.focused_id {
+                    self.app.on_focused_input(id, &char_event)
+                } else { false };
+                if !handled {
+                    self.app.on_input(&char_event);
+                }
+            }
+        }
+    }
     /// `self.text_layouts` を走査して mouse 座標に最も近い (text_idx, byte_offset)
     /// を返す。 hit_regions の hit 判定で取れなかった「テキスト本文上のクリック」
     /// で selection を始めるのに使う。 戻り値 None = どの text 要素にも近くない
@@ -3104,6 +3135,10 @@ mod frame_tests {
         probes: Vec<String>,
         /// `probe_positions` as of the most recent `on_build`.
         probed: std::collections::HashMap<String, f32>,
+        /// `on_input` で受けたキーイベントを (key, pressed, shift) で順に記録する。
+        keys: Vec<(Key, bool, bool)>,
+        /// `on_input` で受けた文字。
+        chars: Vec<char>,
     }
 
     impl DeclarativeApp for RecordingApp {
@@ -3120,6 +3155,17 @@ mod frame_tests {
 
         fn build_probes(&self) -> Vec<String> {
             self.probes.clone()
+        }
+
+        fn on_input(&mut self, event: &InputEvent) -> bool {
+            match event {
+                InputEvent::KeyInput { key, pressed, modifiers } => {
+                    self.keys.push((*key, *pressed, modifiers.shift));
+                }
+                InputEvent::CharInput(ch) => self.chars.push(*ch),
+                _ => {}
+            }
+            false
         }
 
         fn on_build(&mut self, build: &sabitori_core::build::BuildResult) {
@@ -3365,6 +3411,70 @@ mod frame_tests {
         });
         let frame = state.build_frame(400.0, 300.0, &StubMeasure);
         assert!(frame.overlay_build.is_none());
+    }
+
+    // -----------------------------------------------------------------
+    // キー入力のルーティング
+    // -----------------------------------------------------------------
+
+    /// 本題の回帰: 解放が届かないと、アプリは「⇧を押している間」を持てない。
+    /// 押下だけを配っていた頃は、押しっぱなしフラグが二度と落ちなかった。
+    #[test]
+    fn key_release_reaches_the_app() {
+        let mut state = AppState::new(RecordingApp::default());
+
+        state.modifiers = Modifiers { shift: true, ..Default::default() };
+        state.handle_key_input(Key::Shift, true, Vec::new());
+        state.modifiers = Modifiers::default();
+        state.handle_key_input(Key::Shift, false, Vec::new());
+
+        assert_eq!(
+            state.app.keys,
+            vec![(Key::Shift, true, true), (Key::Shift, false, false)],
+            "押下と解放が両方、その時点の修飾キー付きで届くこと"
+        );
+    }
+
+    /// 解放は「アプリへ転送する」だけ。副作用（選択解除・文字入力）まで走らせると、
+    /// ⇧を離しただけで選択が消えるといった別のバグになる。
+    #[test]
+    fn key_release_has_no_side_effects() {
+        let mut state = AppState::new(RecordingApp::default());
+        state.selection = Some(TextSelection {
+            anchor: (0, 0),
+            head: (0, 3),
+            anchor_content: "abc".into(),
+            head_content: "abc".into(),
+        });
+
+        // 解放は選択を消さない。chars を渡しても文字入力にはならない
+        // （実際の呼び出し側でも char_inputs は解放時に空を返す）。
+        state.handle_key_input(Key::A, false, vec!['a']);
+        assert!(state.selection.is_some(), "解放で選択が消えてはいけない");
+        assert!(state.app.chars.is_empty(), "解放で文字が入ってはいけない");
+
+        // 押下は従来どおり選択を解除し、文字を流す。
+        state.handle_key_input(Key::A, true, vec!['a']);
+        assert!(state.selection.is_none(), "押下は選択を解除する");
+        assert_eq!(state.app.chars, vec!['a']);
+    }
+
+    /// 修飾キー単独押下は `Key::Other` に落ちることがあり、それは選択を消さない
+    /// （⌘を押してから C、が選択を先に消してしまうため）。解放でも同じ。
+    #[test]
+    fn bare_modifier_does_not_clear_the_selection() {
+        let mut state = AppState::new(RecordingApp::default());
+        state.selection = Some(TextSelection {
+            anchor: (0, 0),
+            head: (0, 3),
+            anchor_content: "abc".into(),
+            head_content: "abc".into(),
+        });
+
+        state.handle_key_input(Key::Other, true, Vec::new());
+        assert!(state.selection.is_some());
+        state.handle_key_input(Key::Other, false, Vec::new());
+        assert!(state.selection.is_some());
     }
 }
 

--- a/crates/sabitori/src/scene_app.rs
+++ b/crates/sabitori/src/scene_app.rs
@@ -420,12 +420,14 @@ impl<A: SceneApp> ApplicationHandler for SceneAppState<A> {
                             kind: PointerKind::Mouse,
                             position: pos,
                             button: Some(sabi_btn),
+                            modifiers: self.modifiers,
                         },
                         winit::event::ElementState::Released => InputEvent::PointerReleased {
                             id: MOUSE_POINTER_ID,
                             kind: PointerKind::Mouse,
                             position: pos,
                             button: Some(sabi_btn),
+                            modifiers: self.modifiers,
                         },
                     };
                     self.app.on_input(&event);
@@ -561,6 +563,7 @@ impl<A: SceneApp> ApplicationHandler for SceneAppState<A> {
                             kind: PointerKind::Touch,
                             position: pos,
                             button: None,
+                            modifiers: self.modifiers,
                         });
                     }
                     winit::event::TouchPhase::Moved => {
@@ -578,6 +581,7 @@ impl<A: SceneApp> ApplicationHandler for SceneAppState<A> {
                             kind: PointerKind::Touch,
                             position: pos,
                             button: None,
+                            modifiers: self.modifiers,
                         });
                     }
                     winit::event::TouchPhase::Cancelled => {

--- a/crates/sabitori/tests/facade.rs
+++ b/crates/sabitori/tests/facade.rs
@@ -28,16 +28,37 @@ fn pointer_events_are_constructible_through_the_facade() {
             kind: PointerKind::Mouse,
             position: at,
             button: Some(MouseButton::Left),
+            modifiers: Modifiers::default(),
         },
         InputEvent::PointerReleased {
             id: 7 as PointerId,
             kind: PointerKind::Touch,
             position: at,
             button: None,
+            modifiers: Modifiers::default(),
         },
         InputEvent::PointerCancelled { id: 8, kind: PointerKind::Pen },
     ];
     assert_eq!(events.len(), 4);
+}
+
+/// ⇧+クリック（選択に足す／外す）が下流で書けること。押下**時点**の修飾キーが
+/// イベントに載っていないと、アプリは `KeyInput` を自前で追って押下状態を保持する
+/// しかなく、それは解放イベントが来て初めて成立する。
+#[test]
+fn pointer_press_carries_the_modifiers_held_at_that_moment() {
+    let ev = InputEvent::PointerPressed {
+        id: MOUSE_POINTER_ID,
+        kind: PointerKind::Mouse,
+        position: Point::new(10.0, 20.0),
+        button: Some(MouseButton::Left),
+        modifiers: Modifiers { shift: true, ..Default::default() },
+    };
+    let shift_click = matches!(
+        ev,
+        InputEvent::PointerPressed { modifiers: Modifiers { shift: true, .. }, .. }
+    );
+    assert!(shift_click, "押下イベントから⇧が読めない");
 }
 
 /// `PointerState` は re-export されているが、 `find` の戻り値と `upsert` の引数は


### PR DESCRIPTION
修飾キーつきのポインタ操作（⇧+クリック = 選択に足す／外す、⌥+ドラッグ = 複製）が
`DeclarativeApp` の上で書けなかった。値は runtime が既に握っているのに **façade が
落としていた** 2 箇所を塞ぐ。

winit を自前で回している bamiri が同じことをできていたのは façade を通っていないから
であって、sabitori に情報が無かったわけではない、という issue の見立てのとおりだった。

## 1. キーの解放がアプリに届かない

`WindowEvent::KeyboardInput` が `ElementState::Pressed` で絞っていたため、
`InputEvent::KeyInput { pressed: false, .. }` が一度も発行されていなかった。

⇧単独の押下は `Key::Shift` として届くのに離したことが分からないので、アプリ側で
「押しっぱなし」を保持すると**二度と落ちない**。押下・解放の両方を転送するようにした。

副作用（コピー・選択解除・フォーカス移動・文字入力）は従来どおり**押下でだけ**走る。
解放でも走らせると、⇧を離しただけで選択が消える別のバグになる。

## 2. `PointerPressed` / `PointerReleased` に `modifiers`

```rust
InputEvent::PointerPressed { position, modifiers, .. } => {
    if modifiers.shift { self.toggle_at(*position) } else { self.select_at(*position) }
}
```

押した**瞬間**の状態が無いと、アプリは `KeyInput` を自前で追って状態機械を持つしか
なく、それは 1 が直って初めて成立する。ポインタ操作にはこちらが素直、という issue の
指摘に沿った。

3 ランタイム（`DeclarativeApp` / `SceneApp` / `SabitoriApp`）とも既に修飾キー状態を
保持しているので、埋めるだけで済んだ。タッチ経路にも同じく載せている。
`PointerReleased` の値は押下時と違いうる（押してから⇧を足す／離す）ので、
`PointerPressed` の値を使い回さないこと。

## ⚠️ 破壊的変更

この 2 variant を**構築**しているコード、および全フィールドを列挙して `match` して
いるコードは修正が要る（`..` で受けているなら無傷）。

## テスト

`DeclarativeApp` のキーボード処理を `AppState::handle_key_input(key, pressed, chars)`
に切り出した。winit 依存が `WindowEvent::KeyboardInput` の数行だけになり、押下／解放の
ルーティングをヘッドレスで検査できる（**「押下だけ配る」形に戻したら落ちる**）。

- 解放が、その時点の修飾キー付きでアプリに届く
- 解放に副作用が無い（選択が消えない・文字が入らない）／押下では従来どおり両方起きる
- 修飾キー単独（`Key::Other`）は押下でも解放でも選択を消さない
- `tests/facade.rs`: ⇧+クリックがファサードだけで書けること

`cargo test --workspace` green（28 スイート）。

## issue の「ついでに」について

`PointerKind` の re-export 漏れは **v0.3.13 で解決済み**（`crates/sabitori/src/lib.rs`）。
`tests/facade.rs` がファサード経由の構築をコンパイル時に保証しており、押下経路の
ヘッドレス検査も本 PR で 1 本足した。参照されていた `#69` は番号としては行き先が無いが、
中身は既に閉じている。

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)