### PR TITLE
feat(style): 押下状態を追い、scale を描画経路に通す (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,62 @@
 
 ## [Unreleased]
 
+押下の手応えが出る版。`.active()` / `.pressable()` が `DeclarativeApp` の上で
+黙って無視されていたのを直し、その過程で「誰にも読まれていなかった」`scale` を
+描画経路に通した。
+
+### Fixed
+- **`.active()` / `.pressable()` が `DeclarativeApp` で効かない**
+  ([#3](https://github.com/Mutafika/sabitori/issues/3))。runtime に押されている要素を
+  追う状態が無く、`Element::active_style` を読む所が declarative 経路に一つも
+  無かった。コンパイルは通り hover は効くので、**押下だけが黙って無視される**
+  — 消費側からは「書き方を間違えた」のか「効かない」のか区別が付かなかった。
+
+  `pressed_id` を持ち、押下でカーソル下の要素を覚え、解放・キャンセル・ウィンドウ外
+  への離脱で消す。`active_style` は hover の**後**に畳むので押下が hover に勝つ
+  （`NodeStyle::effective_style` と同じ規約）。タッチでも同じく効く。
+
+- **`StateStyle::scale` が誰にも読まれていなかった**
+  ([#3](https://github.com/Mutafika/sabitori/issues/3))。`ElementStyle` に `scale`
+  フィールドが無く、declarative でも scene でも参照されていなかったため、
+  `.hover(|s| s.scale(1.1))` も `.active(|s| s.scale(0.95))` も無反応だった。
+
+  つまり `pressable()`（中身が `scale` + hover bg）は **cursor と hover の bg しか
+  効いていなかった**。押下状態を追うだけでは issue の例は動かないままなので、
+  併せて塞いだ。
+
+- **`apply_hover_styles` が `StateStyle` の半分を落としていた**。`scale` /
+  `translate_x` / `translate_y` / `gap` / `width` / `height` / `padding` が畳まれず、
+  15 フィールド中 7 つが declarative 経路では死んでいた。全フィールドを畳むようにした。
+  レイアウトを変えるフィールドも扱えるのは、畳みが build の前に走るため。
+
+### Added
+- **`ElementStyle::scale`（と `Element::scaled()`）** — 要素の**中心**を軸にした
+  視覚のみの拡大縮小。CSS の `transform: scale()` と同じく**レイアウトはやり直さない**
+  ので、押されたボタンが縮んでも隣の行は動かない。
+
+  subtree 全部に乗る（子の位置・寸法、文字サイズ、角丸、線幅、影、polyline の点）。
+  **hit region も一緒に変換される**ので、見えている場所と押せる場所がずれない。
+  `opacity` と同じく乗算で継承する。
+
+### Changed
+- **`button()` が既定で押し込みの手応えを持つようになった。** hover で 1.02、
+  押下で 0.96 に scale する。色に触らないのは、正しい hover 色がパレット依存で、
+  `.accent()` を付けたボタンと決め打ちの色が喧嘩するため。`.hover()` / `.active()`
+  を書けば丸ごと上書きされる。
+
+  ⚠️ **既存アプリの button の見た目が変わる**（今まで無反応だったものが動く）。
+
+- `hover` / `active` の畳み込みを `sabitori_core::element::apply_state_styles` に
+  一本化した。`DeclarativeApp` と `SceneApp` が同じ関数を呼ぶので、どちらの
+  ランタイムで動かしても状態解決が一致する（`SceneApp` 側は "ported verbatim" の
+  複製を持っていて、放っておくと片方だけ直って乖離する形だった）。
+  呼び出し元ゼロで `scale` を落としていた `StateStyle::apply_to` も同じ実体に寄せた。
+
+- `StyleAnimator::update` が `pressed_id` を受け取るようになった。transitions を
+  持つ要素（`button()` は既定で持つ）でも `active_style` が効く。
+  ⚠️ **破壊的変更**: 引数が 1 つ増えている。
+
 ## [0.3.14] - 2026-08-10
 
 修飾キーつきのポインタ操作（⇧+クリック = 選択に足す／外す、⌥+ドラッグ = 複製）が

--- a/crates/sabitori-core/src/build.rs
+++ b/crates/sabitori-core/src/build.rs
@@ -278,6 +278,7 @@ fn build_tree_impl(
         &mut element_counter,
         false,
         false,
+        1.0,
         None,
         probes,
         &mut probe_positions,
@@ -523,20 +524,36 @@ fn emit_commands(
     // `user-select: none` の継承状態。 ある要素で `.no_select()` が立つと、 そこから
     // 下の TextDraw が全部 `no_select` になる (CSS の `user-select` と同じ継承)。
     parent_no_select: bool,
+    // 祖先が課した視覚 scale の累積 (根は 1.0)。 レイアウト空間の px を画面 px に
+    // 直す係数で、 opacity と同じく乗算で下りていく。
+    parent_scale: f32,
     parent_clip: Option<Rect>,
     probes: &std::collections::HashSet<String>,
     probe_positions: &mut std::collections::HashMap<String, f32>,
 ) {
     let layout = taffy.layout(taffy_node).expect("Missing layout");
     let style = &element.style;
+    // `scale` cascades multiplicatively like opacity: `parent_scale` is what
+    // ancestors already imposed, `scale` adds this element's own on top and is
+    // what everything *inside* it (children, text, radii, borders) is drawn at.
+    // Layout is never redone — taffy measured everything at 1.0, so scaling is
+    // a pure post-layout transform and siblings never move (the whole point of
+    // a press affordance: the button shrinks, the row does not reflow).
+    let scale = parent_scale * style.scale;
     // `translate_x/y` are visual-only offsets applied AFTER taffy layout —
     // they shift the rendered rect + hit region without telling taffy, so
     // sibling layout stays put while a hover spring "pulls" or "lifts"
     // this element. Children inherit the shifted origin via abs_x/abs_y.
-    let abs_x = parent_x + layout.location.x + style.translate_x;
-    let abs_y = parent_y + layout.location.y + style.translate_y;
-    let w = layout.size.width;
-    let h = layout.size.height;
+    // Layout-space offsets arrive in unscaled px, so the *inherited* factor
+    // converts them to screen px; this element's own factor is not in play yet.
+    let slot_x = parent_x + (layout.location.x + style.translate_x) * parent_scale;
+    let slot_y = parent_y + (layout.location.y + style.translate_y) * parent_scale;
+    let w = layout.size.width * scale;
+    let h = layout.size.height * scale;
+    // Own scale pivots on the element's center — growing on hover must not
+    // shift the top-left corner, or a 1.1 hover would visibly slide the widget.
+    let abs_x = slot_x + (layout.size.width * parent_scale - w) * 0.5;
+    let abs_y = slot_y + (layout.size.height * parent_scale - h) * 0.5;
     // Opacity cascades multiplicatively: a parent at 0.4 with a child at
     // 0.8 produces an effective 0.32 — matching CSS / SwiftUI / every
     // other tree-based UI system. Without this, fading a popup panel
@@ -581,7 +598,7 @@ fn emit_commands(
                     taffy, child_elem, child_taffy,
                     abs_x, abs_y, effective_opacity, render_list, overlay_list,
                     hit_regions, overlay_hit_regions, scroll_measures, element_counter, use_overlay,
-                    no_select,
+                    no_select, scale,
                     parent_clip,
                     probes, probe_positions,
                 );
@@ -612,14 +629,14 @@ fn emit_commands(
 
         target.commands.push(RenderCommand::Rect(RectDraw {
             rect,
-            corner_radii: style.corner_radius,
+            corner_radii: scale_corners(style.corner_radius, scale),
             fill_color: apply_opacity(bg, effective_opacity),
             border_color: apply_opacity(style.border_color, effective_opacity),
-            border_width: style.border_width,
+            border_width: style.border_width * scale,
             shadow_color: apply_opacity(shadow_color, effective_opacity),
-            shadow_offset,
-            shadow_blur,
-            shadow_spread,
+            shadow_offset: Point::new(shadow_offset.x * scale, shadow_offset.y * scale),
+            shadow_blur: shadow_blur * scale,
+            shadow_spread: shadow_spread * scale,
             opacity: effective_opacity,
             gradient_angle: style.gradient_angle,
             gradient_end_color: apply_opacity(style.gradient_end, effective_opacity),
@@ -630,13 +647,15 @@ fn emit_commands(
     // Emit text draw for Text and Button elements
     match &element.kind {
         ElementKind::Text { content } => {
-            let padding = resolve_edges_px(&style.padding);
+            // padding はレイアウト空間の px なので、描画位置に使う前に scale する
+            // （箱だけ縮んで中の字が元の位置に残る、を防ぐ）。
+            let padding = scale_edges(resolve_edges_px(&style.padding), scale);
             target.commands.push(RenderCommand::Text(TextDraw {
                 content: content.clone(),
                 position: Point::new(abs_x + padding.0, abs_y + padding.1),
                 max_width: (w - padding.0 - padding.2).max(0.0),
                 max_height: (h - padding.1 - padding.3).max(0.0),
-                font_size: style.font_size,
+                font_size: style.font_size * scale,
                 color: apply_opacity(style.color, effective_opacity),
                 bold: style.bold,
                 monospace: style.monospace,
@@ -653,13 +672,13 @@ fn emit_commands(
         }
         ElementKind::Button { label, .. } => {
             // Button label is centered text
-            let padding = resolve_edges_px(&style.padding);
+            let padding = scale_edges(resolve_edges_px(&style.padding), scale);
             target.commands.push(RenderCommand::Text(TextDraw {
                 content: label.clone(),
                 position: Point::new(abs_x + padding.0, abs_y + padding.1),
                 max_width: (w - padding.0 - padding.2).max(0.0),
                 max_height: (h - padding.1 - padding.3).max(0.0),
-                font_size: style.font_size,
+                font_size: style.font_size * scale,
                 color: apply_opacity(style.color, effective_opacity),
                 bold: style.bold,
                 monospace: style.monospace,
@@ -681,7 +700,7 @@ fn emit_commands(
             let cx = abs_x + w * 0.5;
             let cy = abs_y + h * 0.5;
             let outer_radius = (w.min(h) * 0.5).max(0.0);
-            let inner_radius = (outer_radius - arc.thickness).max(0.0);
+            let inner_radius = (outer_radius - arc.thickness * scale).max(0.0);
             target.commands.push(RenderCommand::Ring(RingDraw {
                 center: Point::new(cx, cy),
                 outer_radius,
@@ -699,11 +718,11 @@ fn emit_commands(
                 let pts = pl
                     .points
                     .iter()
-                    .map(|(px, py)| Point::new(abs_x + *px, abs_y + *py))
+                    .map(|(px, py)| Point::new(abs_x + *px * scale, abs_y + *py * scale))
                     .collect();
                 target.commands.push(RenderCommand::Polyline(PolylineDraw {
                     points: pts,
-                    width: pl.width.max(0.0),
+                    width: (pl.width * scale).max(0.0),
                     color: apply_opacity(pl.color, effective_opacity),
                 }));
             }
@@ -713,7 +732,7 @@ fn emit_commands(
                 key: key.clone(),
                 data: data.clone(),
                 rect,
-                corner_radii: style.corner_radius,
+                corner_radii: scale_corners(style.corner_radius, scale),
                 opacity: effective_opacity,
                 object_fit: style.object_fit,
             }));
@@ -877,7 +896,7 @@ fn emit_commands(
                     if !probes.is_empty() {
                         record_probes(
                             taffy, child_elem, child_taffy,
-                            abs_x + child_offset_x, abs_y + child_offset_y,
+                            abs_x + child_offset_x * scale, abs_y + child_offset_y * scale,
                             probes, probe_positions,
                         );
                     }
@@ -887,11 +906,11 @@ fn emit_commands(
 
             emit_commands(
                 taffy, child_elem, child_taffy,
-                abs_x + child_offset_x, abs_y + child_offset_y,
+                abs_x + child_offset_x * scale, abs_y + child_offset_y * scale,
                 effective_opacity,
                 render_list, overlay_list,
                 hit_regions, overlay_hit_regions, scroll_measures, element_counter, use_overlay,
-                no_select,
+                no_select, scale,
                 child_clip,
                 probes, probe_positions,
             );
@@ -1222,6 +1241,23 @@ fn resolve_edges_px(
         dim_to_px(edges.right),
         dim_to_px(edges.bottom),
     )
+}
+
+/// 4 辺の px を一様に scale する。`resolve_edges_px` の戻り値 (left, top, right,
+/// bottom) をそのまま受ける。
+fn scale_edges(e: (f32, f32, f32, f32), scale: f32) -> (f32, f32, f32, f32) {
+    (e.0 * scale, e.1 * scale, e.2 * scale, e.3 * scale)
+}
+
+/// 角丸半径を一様に scale する。箱だけ縮んで角丸が据え置きだと、小さい箱ほど
+/// 丸が効きすぎて別の形に見える。
+fn scale_corners(c: Corners<f32>, scale: f32) -> Corners<f32> {
+    Corners {
+        top_left: c.top_left * scale,
+        top_right: c.top_right * scale,
+        bottom_right: c.bottom_right * scale,
+        bottom_left: c.bottom_left * scale,
+    }
 }
 
 fn dim_to_px(d: Dimension) -> f32 {
@@ -1649,6 +1685,178 @@ mod tests {
         assert_eq!(texts.len(), 2);
         assert!(texts[0].no_select, "sidebar");
         assert!(!texts[1].no_select, "prose は選択可能のまま");
+    }
+
+    // -----------------------------------------------------------------
+    // hover / active の畳み込み (#3)
+    // -----------------------------------------------------------------
+
+    fn folded(mut el: Element, hovered: Option<&str>, pressed: Option<&str>) -> Element {
+        crate::element::apply_state_styles(
+            &mut el,
+            &hovered.map(str::to_string),
+            &pressed.map(str::to_string),
+        );
+        el
+    }
+
+    /// 本題の回帰: `.active()` が畳まれること。押下状態を追う所が無かった頃は、
+    /// この style は誰にも読まれずに捨てられていた。
+    #[test]
+    fn active_style_is_folded_while_pressed() {
+        let el = || div().id("save").bg(Color::BLACK).active(|s| s.scale(0.95));
+
+        assert_eq!(folded(el(), None, None).style.scale, 1.0, "素のときは素通し");
+        assert_eq!(folded(el(), None, Some("save")).style.scale, 0.95);
+        assert_eq!(folded(el(), None, Some("other")).style.scale, 1.0, "他人の押下では効かない");
+    }
+
+    /// 押下は hover に勝つ (`NodeStyle::effective_style` と同じ規約)。
+    #[test]
+    fn active_wins_over_hover() {
+        let el = div()
+            .id("b")
+            .hover(|s| s.scale(1.1).bg(Color::WHITE))
+            .active(|s| s.scale(0.95));
+        let out = folded(el, Some("b"), Some("b"));
+
+        assert_eq!(out.style.scale, 0.95, "押下中は active の値");
+        assert_eq!(
+            out.style.background, Color::WHITE,
+            "active が触っていないフィールドは hover の値が残る"
+        );
+    }
+
+    /// transitions を持つ要素でも、StyleAnimator が扱わないフィールドは即時に
+    /// 効く。ここを飛ばすと `.spring_transition()` を足した瞬間に `.active()` の
+    /// scale が黙って死ぬ — 一番たちの悪い形になる。
+    #[test]
+    fn animated_elements_still_get_the_fields_the_animator_cannot_reach() {
+        let el = div()
+            .id("b")
+            .bg(Color::BLACK)
+            .spring_transition(300.0, 25.0)
+            .active(|s| s.scale(0.95).bg(Color::WHITE));
+        let out = folded(el, None, Some("b"));
+
+        assert_eq!(out.style.scale, 0.95, "scale は animator が扱わない → 即時");
+        assert_eq!(
+            out.style.background, Color::BLACK,
+            "bg は animator の担当 → ここでは触らない (補間を潰さない)"
+        );
+    }
+
+    /// レイアウトを変えるフィールドも畳める。畳みは build の前に走るので、
+    /// taffy は畳んだ後の値をそのまま測る。
+    #[test]
+    fn state_styles_can_change_layout() {
+        let el = div().id("b").w(Px(100.0)).h(Px(40.0)).active(|s| s.w(Px(120.0)));
+        let out = folded(el, None, Some("b"));
+        let result = build_tree(&out, 800.0, 600.0);
+        let region = result.hit_regions.iter().find(|r| r.id.as_deref() == Some("b")).unwrap();
+
+        assert_eq!(region.rect.size.width, 120.0);
+    }
+
+    /// `button()` は既定で押し込みの手応えを持つ — consumer が毎回組み立てないで済む。
+    #[test]
+    fn button_has_a_default_press_affordance() {
+        let b = button("OK").id("ok");
+        assert!(b.active_style.is_some(), "button に既定の active_style が無い");
+
+        let pressed = folded(button("OK").id("ok"), None, Some("ok"));
+        assert!(pressed.style.scale < 1.0, "押下で縮むこと");
+        let hovered = folded(button("OK").id("ok"), Some("ok"), None);
+        assert!(hovered.style.scale > 1.0, "hover で少し持ち上がること");
+    }
+
+    // -----------------------------------------------------------------
+    // scale — レイアウトを動かさない視覚 transform (#3)
+    // -----------------------------------------------------------------
+
+    /// scale は要素の**中心**を軸に効く。左上を軸にすると、hover で 1.1 に
+    /// なった瞬間にウィジェットが右下へずれて見える。
+    #[test]
+    fn scale_pivots_on_the_center() {
+        let root = div().w(Px(200.0)).h(Px(100.0)).children([
+            div().w(Px(100.0)).h(Px(100.0)).bg(Color::WHITE).scaled(0.5),
+        ]);
+        let result = build_tree(&root, 800.0, 600.0);
+        let r = result.render_list.rects().next().unwrap().rect;
+
+        assert_eq!(r.size.width, 50.0);
+        assert_eq!(r.size.height, 50.0);
+        // 中心 (50, 50) は動かない → 原点は (25, 25)。
+        assert_eq!(r.origin.x, 25.0);
+        assert_eq!(r.origin.y, 25.0);
+    }
+
+    /// レイアウトはやり直さない。押されたボタンが縮んでも隣の行は動かない、が
+    /// 押下フィードバックの前提。
+    #[test]
+    fn scale_does_not_move_siblings() {
+        let scaled = div().w(Px(200.0)).flex_row().children([
+            div().w(Px(100.0)).h(Px(40.0)).bg(Color::WHITE).scaled(0.5),
+            div().w(Px(100.0)).h(Px(40.0)).bg(Color::BLACK),
+        ]);
+        let plain = div().w(Px(200.0)).flex_row().children([
+            div().w(Px(100.0)).h(Px(40.0)).bg(Color::WHITE),
+            div().w(Px(100.0)).h(Px(40.0)).bg(Color::BLACK),
+        ]);
+        let a = build_tree(&scaled, 800.0, 600.0);
+        let b = build_tree(&plain, 800.0, 600.0);
+        let sib_a = a.render_list.rects().nth(1).unwrap().rect;
+        let sib_b = b.render_list.rects().nth(1).unwrap().rect;
+
+        assert_eq!(sib_a.origin.x, sib_b.origin.x, "隣は動かない");
+        assert_eq!(sib_a.size.width, sib_b.size.width, "隣は縮まない");
+    }
+
+    /// subtree 全部に乗る — 子の位置・寸法も、文字の大きさも。箱だけ縮んで
+    /// 中身が元寸のままだと、押し込みではなく「枠が欠けた」ように見える。
+    #[test]
+    fn scale_cascades_to_children_and_text() {
+        let root = div().w(Px(200.0)).h(Px(200.0)).scaled(0.5).children([
+            div().w(Px(100.0)).h(Px(100.0)).bg(Color::WHITE).children([
+                text("x").font_size(20.0),
+            ]),
+        ]);
+        let result = build_tree(&root, 800.0, 600.0);
+
+        let child = result.render_list.rects().next().unwrap().rect;
+        assert_eq!(child.size.width, 50.0, "子も半分になる");
+        let t = result.render_list.texts().next().unwrap();
+        assert_eq!(t.font_size, 10.0, "文字も半分になる");
+    }
+
+    /// hit region も一緒に変換されること。見えている場所と押せる場所がずれると、
+    /// 縮んだボタンの縁が「押せるのに反応しない」帯になる。
+    #[test]
+    fn scale_transforms_the_hit_region() {
+        let root = div().w(Px(200.0)).h(Px(100.0)).children([
+            div().id("btn").w(Px(100.0)).h(Px(100.0)).bg(Color::WHITE).scaled(0.5),
+        ]);
+        let result = build_tree(&root, 800.0, 600.0);
+        let region = result
+            .hit_regions
+            .iter()
+            .find(|r| r.id.as_deref() == Some("btn"))
+            .expect("hit region for btn");
+
+        assert_eq!(region.rect.origin.x, 25.0);
+        assert_eq!(region.rect.size.width, 50.0);
+    }
+
+    /// 既定は 1.0 = 素通し。既存アプリの見た目が 1px も動かないこと。
+    #[test]
+    fn unscaled_geometry_is_untouched() {
+        let root = div().w(Px(120.0)).h(Px(60.0)).bg(Color::WHITE).rounded_px(8.0);
+        let result = build_tree(&root, 800.0, 600.0);
+        let d = result.render_list.rects().next().unwrap();
+
+        assert_eq!(d.rect.origin.x, 0.0);
+        assert_eq!(d.rect.size.width, 120.0);
+        assert_eq!(d.corner_radii.top_left, 8.0);
     }
 
     /// button の label はコントロールのキャプションであって本文ではないので、

--- a/crates/sabitori-core/src/element.rs
+++ b/crates/sabitori-core/src/element.rs
@@ -323,6 +323,20 @@ pub struct ElementStyle {
     pub translate_x: f32,
     /// Visual-only Y offset. See `translate_x` for semantics.
     pub translate_y: f32,
+    /// Visual-only uniform scale about the element's **center**, applied after
+    /// layout and inherited by the whole subtree — the CSS `transform: scale()`
+    /// model. `1.0` (default) = no scaling.
+    ///
+    /// Nothing is re-laid-out: taffy still measures the element at its natural
+    /// size and siblings stay put, so a button that scales to 0.95 on press
+    /// doesn't shove the row around. Everything drawn inside scales with it —
+    /// rect geometry, corner radii, border and shadow widths, font sizes,
+    /// polyline points — and so does the hit region, which keeps the pointer
+    /// and the pixels in agreement.
+    ///
+    /// This is what `.hover(|s| s.scale(1.1))` / `.active(|s| s.scale(0.95))`
+    /// fold into.
+    pub scale: f32,
 
     // Text (inherited)
     pub color: Color,
@@ -409,6 +423,7 @@ impl Default for ElementStyle {
             rotation: 0.0,
             translate_x: 0.0,
             translate_y: 0.0,
+            scale: 1.0,
             color: Color::WHITE,
             font_size: 14.0,
             bold: false,
@@ -556,44 +571,13 @@ pub struct StateStyle {
 
 impl StateStyle {
     /// Merge this state style onto a base ElementStyle, returning a new resolved style.
+    ///
+    /// フィールドの取りこぼしを防ぐため、畳み込み自体は [`fold_state_style`] に
+    /// 一本化してある（かつて 3 箇所に同じ列挙があり、ここだけ `scale` /
+    /// `translate_*` を落としていた）。
     pub fn apply_to(&self, base: &ElementStyle) -> ElementStyle {
         let mut s = base.clone();
-        if let Some(bg) = self.background {
-            s.background = bg;
-        }
-        if let Some(bc) = self.border_color {
-            s.border_color = bc;
-        }
-        if let Some(bw) = self.border_width {
-            s.border_width = bw;
-        }
-        if let Some(ref shadow) = self.shadow {
-            s.shadow = shadow.clone();
-        }
-        if let Some(op) = self.opacity {
-            s.opacity = op;
-        }
-        if let Some(cr) = self.corner_radius {
-            s.corner_radius = cr;
-        }
-        if let Some(g) = self.gap {
-            s.gap = g;
-        }
-        if let Some(w) = self.width {
-            s.width = w;
-        }
-        if let Some(h) = self.height {
-            s.height = h;
-        }
-        if let Some(p) = self.padding {
-            s.padding = p;
-        }
-        if let Some(c) = self.color {
-            s.color = c;
-        }
-        if let Some(fs) = self.font_size {
-            s.font_size = fs;
-        }
+        fold_state_style(&mut s, self, false);
         s
     }
 }
@@ -742,6 +726,92 @@ impl std::fmt::Debug for Element {
             .field("on_hover", &self.on_hover.as_ref().map(|_| ".."))
             .finish()
     }
+}
+
+// ---------------------------------------------------------------------------
+// State style folding (hover / active)
+// ---------------------------------------------------------------------------
+
+/// Fold the hover and press state styles of a whole tree into its base styles.
+///
+/// Runs on the element tree *before* layout, so state overrides that change
+/// geometry (`width` / `height` / `padding` / `gap`) work like any other style —
+/// taffy simply measures the folded values.
+///
+/// Precedence is press over hover over base, matching
+/// `sabitori_scene::NodeStyle::effective_style`. Both are folded when both
+/// apply, so `.active()` only has to name what actually differs while pressed.
+///
+/// `animated` elements (those with `transitions`) are handled by
+/// `StyleAnimator` for the fields it interpolates; see [`fold_state_style`].
+///
+/// Both runtimes (`DeclarativeApp` and `SceneApp`) call this, so a widget
+/// resolves its states identically no matter which one is driving it.
+pub fn apply_state_styles(
+    element: &mut Element,
+    hovered_id: &Option<String>,
+    pressed_id: &Option<String>,
+) {
+    let is_hovered = element
+        .id
+        .as_deref()
+        .is_some_and(|id| hovered_id.as_deref() == Some(id));
+    let is_pressed = element
+        .id
+        .as_deref()
+        .is_some_and(|id| pressed_id.as_deref() == Some(id));
+    if is_hovered || is_pressed {
+        let animated = !element.transitions.is_empty();
+        // style と hover_style/active_style を同時に触るので、フィールド分割で
+        // 借用を割る。
+        let Element { style, hover_style, active_style, .. } = element;
+        if is_hovered {
+            if let Some(h) = hover_style.as_ref() {
+                fold_state_style(style, h, animated);
+            }
+        }
+        if is_pressed {
+            if let Some(a) = active_style.as_ref() {
+                fold_state_style(style, a, animated);
+            }
+        }
+    }
+    for child in &mut element.children {
+        apply_state_styles(child, hovered_id, pressed_id);
+    }
+}
+
+/// Fold one [`StateStyle`] into an [`ElementStyle`].
+///
+/// `animated` = この要素は `transitions` を持つので `StyleAnimator` がバネで
+/// 補間している。その場合、animator が持っているフィールドをここで即値にすると
+/// 補間を潰してしまうので飛ばす。
+///
+/// animator が扱わないフィールド（scale / translate / 角丸 / 影 / レイアウト系）は
+/// `transitions` の有無に関わらず即時に反映する — さもないと
+/// `.spring_transition()` を足した瞬間に `.active(|s| s.scale(0.95))` が黙って
+/// 効かなくなる、という一番たちの悪い形になる。
+pub fn fold_state_style(style: &mut ElementStyle, s: &StateStyle, animated: bool) {
+    // --- StyleAnimator が扱わない = 常に即時 ---
+    if let Some(v) = s.scale { style.scale = v; }
+    if let Some(v) = s.translate_x { style.translate_x = v; }
+    if let Some(v) = s.translate_y { style.translate_y = v; }
+    if let Some(v) = s.corner_radius { style.corner_radius = v; }
+    if let Some(v) = s.shadow { style.shadow = v; }
+    if let Some(v) = s.gap { style.gap = v; }
+    if let Some(v) = s.width { style.width = v; }
+    if let Some(v) = s.height { style.height = v; }
+    if let Some(v) = s.padding { style.padding = v; }
+    // --- ここから下は StyleAnimator の担当 ---
+    if animated {
+        return;
+    }
+    if let Some(v) = s.background { style.background = v; }
+    if let Some(v) = s.border_color { style.border_color = v; }
+    if let Some(v) = s.border_width { style.border_width = v; }
+    if let Some(v) = s.opacity { style.opacity = v; }
+    if let Some(v) = s.color { style.color = v; }
+    if let Some(v) = s.font_size { style.font_size = v; }
 }
 
 // ---------------------------------------------------------------------------
@@ -905,8 +975,16 @@ pub fn button(label: impl Into<String>) -> Element {
         on_click: None,
         on_hover: None,
         focusable: false,
-        hover_style: None,
-        active_style: None,
+        // A button ships with the affordance built in: it lifts a little under
+        // the pointer and sinks under the press. Colors are deliberately not
+        // touched — the right hover tint depends on the app's palette, and an
+        // `.accent()` button would fight a hardcoded one. Scale is palette-free,
+        // so it reads correctly on any theme.
+        //
+        // Callers who want something else just override with `.hover()` /
+        // `.active()`; those replace these outright.
+        hover_style: Some(StateStyle { scale: Some(1.02), ..StateStyle::default() }),
+        active_style: Some(StateStyle { scale: Some(0.96), ..StateStyle::default() }),
         transitions: vec![Transition {
             property: TransitionProperty::All,
             kind: TransitionKind::default(),
@@ -1403,6 +1481,14 @@ impl Element {
     pub fn xlate(mut self, x: f32, y: f32) -> Self {
         self.style.translate_x = x;
         self.style.translate_y = y;
+        self
+    }
+
+    /// Set a visual-only uniform scale about the element's center. Layout is
+    /// unaffected (siblings stay put) and the whole subtree scales with it —
+    /// see [`ElementStyle::scale`]. `1.0` = no scaling.
+    pub fn scaled(mut self, factor: f32) -> Self {
+        self.style.scale = factor;
         self
     }
 

--- a/crates/sabitori-widgets/src/style_animator.rs
+++ b/crates/sabitori-widgets/src/style_animator.rs
@@ -94,17 +94,33 @@ impl StyleAnimator {
         Self { states: HashMap::new() }
     }
 
-    /// Update animation targets based on current hover state.
-    /// Walk the element tree, and for each element with transitions + hover_style,
-    /// set the animated values to either the hover style or the base style.
-    pub fn update(&mut self, element: &Element, hovered_id: &Option<String>) {
-        self.update_recursive(element, hovered_id);
+    /// Update animation targets based on the current hover / press state.
+    /// Walk the element tree, and for each element with transitions, set the
+    /// animated values to the active style, the hover style, or the base style.
+    ///
+    /// Press wins over hover — the same precedence `NodeStyle::effective_style`
+    /// uses. Without `pressed_id` an element with transitions could never show
+    /// its `active_style` at all, which is how `button()` (transitions by
+    /// default) ended up with no press feedback.
+    pub fn update(
+        &mut self,
+        element: &Element,
+        hovered_id: &Option<String>,
+        pressed_id: &Option<String>,
+    ) {
+        self.update_recursive(element, hovered_id, pressed_id);
     }
 
-    fn update_recursive(&mut self, element: &Element, hovered_id: &Option<String>) {
+    fn update_recursive(
+        &mut self,
+        element: &Element,
+        hovered_id: &Option<String>,
+        pressed_id: &Option<String>,
+    ) {
         if let Some(ref id) = element.id {
             if !element.transitions.is_empty() {
                 let is_hovered = hovered_id.as_deref() == Some(id.as_str());
+                let is_pressed = pressed_id.as_deref() == Some(id.as_str());
                 let spring = spring_from_transitions(element);
 
                 let entry = self.states.entry(id.clone()).or_insert_with(|| {
@@ -118,16 +134,19 @@ impl StyleAnimator {
                     }
                 });
 
-                if is_hovered {
-                    if let Some(ref hover) = element.hover_style {
-                        // Set targets to hover values (or base if not overridden)
-                        entry.bg.set_target(hover.background.unwrap_or(element.style.background));
-                        entry.border_color.set_target(hover.border_color.unwrap_or(element.style.border_color));
-                        entry.color.set_target(hover.color.unwrap_or(element.style.color));
-                        entry.opacity.set_target(hover.opacity.unwrap_or(element.style.opacity));
-                        entry.border_width.set_target(hover.border_width.unwrap_or(element.style.border_width));
-                        entry.font_size.set_target(hover.font_size.unwrap_or(element.style.font_size));
-                    }
+                // 押下 → hover → 素、の順に効く方を選ぶ。押下中でも active_style が
+                // 無ければ hover へ落ちるので、hover だけ書いた要素の挙動は不変。
+                let state = if is_pressed { element.active_style.as_ref() } else { None }
+                    .or(if is_hovered { element.hover_style.as_ref() } else { None });
+
+                if let Some(st) = state {
+                    // Set targets to the state's values (or base if not overridden)
+                    entry.bg.set_target(st.background.unwrap_or(element.style.background));
+                    entry.border_color.set_target(st.border_color.unwrap_or(element.style.border_color));
+                    entry.color.set_target(st.color.unwrap_or(element.style.color));
+                    entry.opacity.set_target(st.opacity.unwrap_or(element.style.opacity));
+                    entry.border_width.set_target(st.border_width.unwrap_or(element.style.border_width));
+                    entry.font_size.set_target(st.font_size.unwrap_or(element.style.font_size));
                 } else {
                     // Return to base style
                     entry.bg.set_target(element.style.background);
@@ -140,7 +159,7 @@ impl StyleAnimator {
             }
         }
         for child in &element.children {
-            self.update_recursive(child, hovered_id);
+            self.update_recursive(child, hovered_id, pressed_id);
         }
     }
 

--- a/crates/sabitori/src/declarative.rs
+++ b/crates/sabitori/src/declarative.rs
@@ -521,6 +521,11 @@ struct AppState<A: DeclarativeApp> {
     mouse_x: f32,
     mouse_y: f32,
     hovered_id: Option<String>,
+    /// 現在押されている要素の id。`active_style` (= `.active()` / `.pressable()`)
+    /// を畳むのに使う。押下で入り、解放・キャンセル・ウィンドウ外への離脱で消える。
+    /// hover と同じく「id を 1 つ持つ」だけの単純な状態で、押したまま外へ払っても
+    /// 解放まで押下表示は続く（CSS の `:active` と同じ）。
+    pressed_id: Option<String>,
     /// Last cursor we asked winit to display. Used to dedup
     /// `set_cursor` calls — flipping the cursor every frame is cheap
     /// but not free, and Apple's NSCursor swap can show up as a
@@ -868,6 +873,9 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
                     return;
                 }
                 self.hovered_id = None;
+                // ウィンドウの外へ出たら押下も解除する。 解放イベントが別ウィンドウで
+                // 起きると戻ってこないので、ここで消さないと押しっぱなしの見た目が残る。
+                self.pressed_id = None;
                 // If a drag is active, notify the app it left the window
                 if let Some((data, _source_id)) = self.drag_manager.drag_info() {
                     self.app.on_drag_out(&data);
@@ -895,6 +903,11 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
                     button: Some(InputMouseButton::Left),
                     modifiers: self.modifiers,
                 });
+                // 押下中の要素を覚える。 次のフレームの `apply_state_styles` が
+                // ここから `active_style` を畳む (#3)。 hover と同じ引き方だが、
+                // 押下対象は `clickable`（= id 付き）で見る — `.active()` は
+                // hover_style を持たない要素にも書けるため。
+                self.pressed_id = self.hit_id_at(self.mouse_x, self.mouse_y);
                 if let Some(ref build) = self.last_build {
                     let pt = sabitori_core::Point::new(self.mouse_x, self.mouse_y);
                     let mut focus_set = false;
@@ -995,6 +1008,7 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
                     button: Some(InputMouseButton::Left),
                     modifiers: self.modifiers,
                 });
+                self.pressed_id = None;
                 // text selection drag 終了。 selection 自体は維持して Cmd+C を待つ。
                 self.selecting = false;
                 // 1 文字も範囲が無いなら (= 単なる click) 視覚 noise になるので消す。
@@ -1136,6 +1150,7 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
                             button: None,
                             modifiers: self.modifiers,
                         });
+                        self.pressed_id = self.hit_id_at(x, y);
                     }
                     winit::event::TouchPhase::Moved => {
                         self.active_touches.insert(touch.id, (x, y));
@@ -1154,6 +1169,7 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
                             button: None,
                             modifiers: self.modifiers,
                         });
+                        self.pressed_id = None;
                     }
                     winit::event::TouchPhase::Cancelled => {
                         self.active_touches.remove(&touch.id);
@@ -1161,6 +1177,7 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
                             id,
                             kind: PointerKind::Touch,
                         });
+                        self.pressed_id = None;
                     }
                 }
 
@@ -1883,6 +1900,7 @@ impl<A: DeclarativeApp> AppState<A> {
             mouse_x: 0.0,
             mouse_y: 0.0,
             hovered_id: None,
+            pressed_id: None,
             last_cursor: None,
             last_ime_area: None,
             last_ime_allowed: true,
@@ -2007,12 +2025,12 @@ impl<A: DeclarativeApp> AppState<A> {
         self.presence_animator.update_presence(&root);
         self.presence_animator.apply(&mut root);
 
-        // Apply hover styles and spring transitions:
+        // Apply hover/active styles and spring transitions:
         // 1. Elements WITH transitions → use StyleAnimator (smooth spring)
-        // 2. Elements with hover_style but NO transitions → instant apply
-        self.style_animator.update(&root, &self.hovered_id);
+        // 2. それ以外、および animator が扱わないフィールド → 即時に畳む
+        self.style_animator.update(&root, &self.hovered_id, &self.pressed_id);
         self.style_animator.apply(&mut root);
-        Self::apply_hover_styles(&mut root, &self.hovered_id);
+        sabitori_core::element::apply_state_styles(&mut root, &self.hovered_id, &self.pressed_id);
 
         // Patch scroll offsets from managed state + register new scroll containers
         crate::scroll_sync::patch_scroll_offsets(&mut root, &mut self.scroll_states);
@@ -2673,27 +2691,17 @@ impl<A: DeclarativeApp> AppState<A> {
 
     /// Instantly apply hover_style overrides to elements that have hover_style
     /// but do NOT have transitions (those are handled by StyleAnimator instead).
-    fn apply_hover_styles(element: &mut Element, hovered_id: &Option<String>) {
-        if let (Some(id), Some(hover)) = (&element.id, &element.hover_style) {
-            // Only apply instant styles for elements WITHOUT transitions
-            if element.transitions.is_empty() {
-                if hovered_id.as_deref() == Some(id.as_str()) {
-                    if let Some(bg) = hover.background { element.style.background = bg; }
-                    if let Some(bc) = hover.border_color { element.style.border_color = bc; }
-                    if let Some(bw) = hover.border_width { element.style.border_width = bw; }
-                    if let Some(op) = hover.opacity { element.style.opacity = op; }
-                    if let Some(cr) = hover.corner_radius { element.style.corner_radius = cr; }
-                    if let Some(c) = hover.color { element.style.color = c; }
-                    if let Some(fs) = hover.font_size { element.style.font_size = fs; }
-                    if let Some(ref shadow) = hover.shadow {
-                        element.style.shadow = shadow.clone();
-                    }
-                }
-            }
-        }
-        for child in &mut element.children {
-            Self::apply_hover_styles(child, hovered_id);
-        }
+    /// 座標の下にある、 id を持つ最前面の hit region の id。 押下対象の解決に使う。
+    /// hover と違って `hoverable` では絞らない — `.active()` だけを書いた要素
+    /// (hover_style 無し) も押下対象になるべきなので、 `clickable` (= id 付き) で見る。
+    fn hit_id_at(&self, x: f32, y: f32) -> Option<String> {
+        let build = self.last_build.as_ref()?;
+        let pt = sabitori_core::Point::new(x, y);
+        build
+            .hit_regions
+            .iter()
+            .find(|r| r.clickable && r.id.is_some() && r.rect.contains(pt))
+            .and_then(|r| r.id.clone())
     }
 
     fn update_hover(&mut self) {
@@ -3411,6 +3419,68 @@ mod frame_tests {
         });
         let frame = state.build_frame(400.0, 300.0, &StubMeasure);
         assert!(frame.overlay_build.is_none());
+    }
+
+    // -----------------------------------------------------------------
+    // 押下状態 (#3)
+    // -----------------------------------------------------------------
+
+    /// 押下対象の解決 → `active_style` の畳み込み、までの配線。runtime に押下を
+    /// 追う状態が無かった頃は `.active()` がどこからも読まれず、押しても何も
+    /// 起きなかった。
+    #[test]
+    fn pressing_an_element_folds_its_active_style() {
+        let tree = || {
+            sabitori_core::div().child(
+                sabitori_core::div()
+                    .id("btn")
+                    .w(sabitori_core::Dimension::Px(100.0))
+                    .h(sabitori_core::Dimension::Px(40.0))
+                    .active(|s| s.scale(0.5)),
+            )
+        };
+        let mut state = AppState::new(RecordingApp {
+            tree: Some(Box::new(tree)),
+            ..Default::default()
+        });
+        run_frame(&mut state, 400.0, 300.0);
+
+        let idle = state.app.rects["btn"];
+        assert_eq!(idle.size.width, 100.0, "押していないので素の寸法");
+
+        // 押下対象がカーソル位置から引けること (mouse_down が使う経路)。
+        assert_eq!(state.hit_id_at(10.0, 10.0).as_deref(), Some("btn"));
+        assert_eq!(state.hit_id_at(300.0, 200.0), None, "外は掴まない");
+
+        // 押下中として組み直すと active_style が乗る。
+        state.pressed_id = Some("btn".to_string());
+        run_frame(&mut state, 400.0, 300.0);
+
+        let pressed = state.app.rects["btn"];
+        assert_eq!(pressed.size.width, 50.0, "押下で縮む");
+        assert_eq!(pressed.origin.x, 25.0, "中心を軸に縮むので原点は内側へ");
+    }
+
+    /// 他の要素を押している間は畳まれない。 押下 id の取り違えは「隣のボタンが
+    /// 凹む」形で出る。
+    #[test]
+    fn pressing_another_element_leaves_this_one_alone() {
+        let mut state = AppState::new(RecordingApp {
+            tree: Some(Box::new(|| {
+                sabitori_core::div().child(
+                    sabitori_core::div()
+                        .id("btn")
+                        .w(sabitori_core::Dimension::Px(100.0))
+                        .h(sabitori_core::Dimension::Px(40.0))
+                        .active(|s| s.scale(0.5)),
+                )
+            })),
+            ..Default::default()
+        });
+        state.pressed_id = Some("someone-else".to_string());
+        run_frame(&mut state, 400.0, 300.0);
+
+        assert_eq!(state.app.rects["btn"].size.width, 100.0);
     }
 
     // -----------------------------------------------------------------

--- a/crates/sabitori/src/scene_app.rs
+++ b/crates/sabitori/src/scene_app.rs
@@ -72,6 +72,9 @@ struct SceneAppState<A: SceneApp> {
     mouse_x: f32,
     mouse_y: f32,
     hovered_id: Option<String>,
+    /// 押下中の要素の id。`active_style` の畳み込みに使う。declarative の
+    /// `AppState` と同じ意味・同じ寿命（押下で入り、解放・キャンセル・離脱で消える）。
+    pressed_id: Option<String>,
     focused_id: Option<String>,
     /// Last cursor we asked winit to display, to dedup `set_cursor`. Mirrors
     /// the field of the same name in the declarative `AppState`.
@@ -166,28 +169,16 @@ impl<A: SceneApp> SceneAppState<A> {
         }
     }
 
-    /// Instantly apply `hover_style` overrides to elements that have a
-    /// hover_style but NO transitions (transitioned elements are handled by
-    /// `StyleAnimator` instead). Ported verbatim from the declarative
-    /// `AppState` so both runtimes resolve hover identically.
-    fn apply_hover_styles(element: &mut sabitori_core::Element, hovered_id: &Option<String>) {
-        if let (Some(id), Some(hover)) = (&element.id, &element.hover_style) {
-            if element.transitions.is_empty() && hovered_id.as_deref() == Some(id.as_str()) {
-                if let Some(bg) = hover.background { element.style.background = bg; }
-                if let Some(bc) = hover.border_color { element.style.border_color = bc; }
-                if let Some(bw) = hover.border_width { element.style.border_width = bw; }
-                if let Some(op) = hover.opacity { element.style.opacity = op; }
-                if let Some(cr) = hover.corner_radius { element.style.corner_radius = cr; }
-                if let Some(c) = hover.color { element.style.color = c; }
-                if let Some(fs) = hover.font_size { element.style.font_size = fs; }
-                if let Some(ref shadow) = hover.shadow {
-                    element.style.shadow = shadow.clone();
-                }
-            }
-        }
-        for child in &mut element.children {
-            Self::apply_hover_styles(child, hovered_id);
-        }
+    /// 座標の下にある、id を持つ最前面の hit region の id。押下対象の解決に使う。
+    /// declarative の `AppState::hit_id_at` と同じ引き方。
+    fn hit_id_at(&self, x: f32, y: f32) -> Option<String> {
+        let build = self.last_build.as_ref()?;
+        let pt = sabitori_core::Point::new(x, y);
+        build
+            .hit_regions
+            .iter()
+            .find(|r| r.clickable && r.id.is_some() && r.rect.contains(pt))
+            .and_then(|r| r.id.clone())
     }
 
     /// Recompute the [`UiCapture`] snapshot and push it to the app when it
@@ -382,6 +373,7 @@ impl<A: SceneApp> ApplicationHandler for SceneAppState<A> {
                     return;
                 }
                 self.hovered_id = None;
+                self.pressed_id = None;
                 // Pointer left the window mid-drag → notify + cancel.
                 if let Some((data, _source_id)) = self.drag_manager.drag_info() {
                     self.app.on_drag_out(&data);
@@ -431,6 +423,14 @@ impl<A: SceneApp> ApplicationHandler for SceneAppState<A> {
                         },
                     };
                     self.app.on_input(&event);
+                }
+
+                // 押下中の要素を覚える → 次フレームで active_style が畳まれる (#3)。
+                if button == winit::event::MouseButton::Left {
+                    self.pressed_id = match state {
+                        winit::event::ElementState::Pressed => self.hit_id_at(pos.x, pos.y),
+                        winit::event::ElementState::Released => None,
+                    };
                 }
 
                 // Also handle DeclarativeApp click/focus semantics
@@ -942,9 +942,13 @@ impl<A: SceneApp> ApplicationHandler for SceneAppState<A> {
                 // the declarative `AppState` redraw path.
                 self.presence_animator.update_presence(&root);
                 self.presence_animator.apply(&mut root);
-                self.style_animator.update(&root, &self.hovered_id);
+                self.style_animator.update(&root, &self.hovered_id, &self.pressed_id);
                 self.style_animator.apply(&mut root);
-                Self::apply_hover_styles(&mut root, &self.hovered_id);
+                sabitori_core::element::apply_state_styles(
+                    &mut root,
+                    &self.hovered_id,
+                    &self.pressed_id,
+                );
 
                 // overflow_scroll コンテナを登録し、現在の offset を要素へ patch する。
                 Self::patch_scroll_offsets(&mut root, &mut self.scroll_states);
@@ -1134,6 +1138,7 @@ pub fn run_scene<A: SceneApp + 'static>(app: A) {
         mouse_x: 0.0,
         mouse_y: 0.0,
         hovered_id: None,
+        pressed_id: None,
         focused_id: None,
         last_cursor: None,
         last_ime_area: None, last_ime_allowed: true,
@@ -1180,6 +1185,7 @@ pub fn run_scene<A: SceneApp + 'static>(app: A) {
         mouse_x: 0.0,
         mouse_y: 0.0,
         hovered_id: None,
+        pressed_id: None,
         focused_id: None,
         last_cursor: None,
         last_ime_area: None, last_ime_allowed: true,


### PR DESCRIPTION
`DeclarativeApp` では `.active()` / `.pressable()` が黙って効かなかった。押されている
要素を追う状態が runtime に無く、`Element::active_style` を読む所が declarative 経路に
**一つも無かった**。コンパイルは通り hover は効くので、消費側からは「書き方を間違えた」
のか「効かない」のか区別が付かない形だった。

## 1. 押下状態を追う

`pressed_id` を持ち、押下でカーソル下の要素を覚え、解放・キャンセル・ウィンドウ外への
離脱で消す。`active_style` は hover の**後**に畳むので押下が hover に勝つ
（`NodeStyle::effective_style` と同じ規約）。タッチでも同じく効く。

## 2. ただし、それだけでは issue の例は動かない

調べたところ **`StateStyle::scale` は誰にも読まれていなかった**。`ElementStyle` に
`scale` フィールドが無く、declarative でも scene でも widgets でも参照ゼロ。つまり

```rust
pub fn pressable(self, hover_bg: Color) -> Self {
    self.cursor(Cursor::Pointer)
        .hover(move |s| s.scale(1.1).bg(hover_bg))   // scale は死んでいた
        .active(|s| s.scale(0.95))                    // 丸ごと死んでいた
}
```

`pressable()` は **cursor と hover の bg しか効いていない**。そして issue が挙げている
例は両方とも scale なので、押下追跡だけ入れても報告された症状は消えない。併せて塞いだ。

- **`ElementStyle::scale`（+ `Element::scaled()`）** — 要素の**中心**を軸にした視覚のみの
  拡大縮小。CSS の `transform: scale()` と同じく**レイアウトはやり直さない**ので、
  押されたボタンが縮んでも隣の行は動かない。subtree 全部に乗る（子の位置・寸法、
  文字サイズ、角丸、線幅、影、polyline の点）。**hit region も一緒に変換される**ので、
  見えている場所と押せる場所がずれない。
- **`apply_hover_styles` が落としていた 7 フィールド**（`scale` / `translate_x` /
  `translate_y` / `gap` / `width` / `height` / `padding`）も畳むようにした。15 フィールド中
  7 つが declarative 経路では死んでいた。畳みは build の**前**に走るので、レイアウトを
  変えるフィールドも普通に扱える。

## 3. 畳み込みの一本化

`sabitori_core::element::apply_state_styles` に寄せ、`DeclarativeApp` と `SceneApp` が
同じ関数を呼ぶようにした。`SceneApp` 側は "ported verbatim so both runtimes resolve
hover identically" という複製を持っていて、放っておくと片方だけ直って doc comment が
嘘になる。呼び出し元ゼロで `scale` / `translate_*` を落としていた `StateStyle::apply_to`
も同じ実体に寄せた（同じ列挙が 3 箇所にあった）。

## 4. `button()` の既定（issue の「ついでに」）

hover で 1.02、押下で 0.96 に scale する。色に触らないのは、正しい hover 色がパレット
依存で、`.accent()` を付けたボタンと決め打ちの色が喧嘩するため。scale はパレット非依存
なのでどのテーマでも成立する。`.hover()` / `.active()` を書けば丸ごと上書きされる。

## ⚠️ 破壊的変更

- `StyleAnimator::update` の引数が 1 つ増える（`pressed_id`）。transitions を持つ要素
  （`button()` は既定で持つ）でも `active_style` が効くようにするため。
- 既存アプリの `button()` の見た目が変わる（今まで無反応だったものが動く）。

## テスト

`cargo test --workspace` green。

- scale: 中心を軸に縮む / 隣は動かない / subtree と文字に乗る / hit region も変換される
  / 既定 1.0 では 1px も動かない
- 畳み込み: `.active()` が畳まれる / 押下が hover に勝つ / transitions 付きでも animator が
  扱わないフィールドは即時に効く / レイアウト系も畳める / `button()` の既定
- runtime: 押下 id の解決 → `active_style` の畳み込みまでの配線 / 他要素の押下では効かない

GUI で動かしての目視確認はしていない。

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)