### PR TITLE
refactor(runtime): 2 ランタイムのポインタ解決を runtime_shared に集約

### DIFF
--- a/crates/sabitori/src/declarative.rs
+++ b/crates/sabitori/src/declarative.rs
@@ -2689,64 +2689,42 @@ impl<A: DeclarativeApp> AppState<A> {
         None
     }
 
-    /// Instantly apply hover_style overrides to elements that have hover_style
-    /// but do NOT have transitions (those are handled by StyleAnimator instead).
-    /// 座標の下にある、 id を持つ最前面の hit region の id。 押下対象の解決に使う。
-    /// hover と違って `hoverable` では絞らない — `.active()` だけを書いた要素
-    /// (hover_style 無し) も押下対象になるべきなので、 `clickable` (= id 付き) で見る。
+    /// 押下対象の解決。 実体は [`crate::runtime_shared::hit_id_at`]。
     fn hit_id_at(&self, x: f32, y: f32) -> Option<String> {
         let build = self.last_build.as_ref()?;
-        let pt = sabitori_core::Point::new(x, y);
-        build
-            .hit_regions
-            .iter()
-            .find(|r| r.clickable && r.id.is_some() && r.rect.contains(pt))
-            .and_then(|r| r.id.clone())
+        crate::runtime_shared::hit_id_at(build, x, y)
     }
 
+    /// ポインタ直下のホバー / tooltip / cursor を引き直し、変化をアプリへ通知する。
+    /// 解決そのものは [`crate::runtime_shared::resolve_hover`]（scene ランタイムと
+    /// 共通）で、ここが足すのは本文中リンクの上書きだけ。
     fn update_hover(&mut self) {
-        let (new_hovered, tooltip_text, hover_cursor) = if let Some(ref build) = self.last_build {
-            let pt = sabitori_core::Point::new(self.mouse_x, self.mouse_y);
-            // Hover lookup: closest hoverable region for hovered_id /
-            // tooltip. Cursor lookup is independent — non-hoverable
-            // regions can still set a cursor (e.g. a text input
-            // declaring `Cursor::Text`), and we walk every region
-            // (front-to-back) to find the first one with a cursor
-            // preference under the cursor.
-            let hover_match = build
-                .hit_regions
-                .iter()
-                .find(|r| r.hoverable && r.rect.contains(pt));
-            let (hovered_id, tooltip) = match hover_match {
-                Some(r) => (r.id.clone(), r.tooltip.clone()),
-                None => (None, None),
-            };
-            let cursor = build
-                .hit_regions
-                .iter()
-                .find(|r| r.cursor.is_some() && r.rect.contains(pt))
-                .and_then(|r| r.cursor);
-            // 本文中リンク上なら tooltip=リンクの preview、cursor=pointer に上書き
-            // （hit_regions は本文段落を hoverable にしないので link_at で別途拾う）。
-            if let Some((link_id, tip)) = self.link_at(self.mouse_x, self.mouse_y) {
-                (Some(link_id), tip.or(tooltip), Some(sabitori_core::Cursor::Pointer))
-            } else {
-                (hovered_id, tooltip, cursor)
-            }
-        } else {
-            (None, None, None)
-        };
+        let mut hit = self
+            .last_build
+            .as_ref()
+            .map(|b| crate::runtime_shared::resolve_hover(b, self.mouse_x, self.mouse_y))
+            .unwrap_or_default();
+        // 本文中リンク上なら tooltip=リンクの preview、cursor=pointer に上書き
+        // （hit_regions は本文段落を hoverable にしないので link_at で別途拾う）。
+        // ここだけが scene ランタイムとの差 — あちらにテキスト選択層は無い。
+        if let Some((link_id, tip)) = self.link_at(self.mouse_x, self.mouse_y) {
+            hit.hovered_id = Some(link_id);
+            hit.tooltip = tip.or(hit.tooltip);
+            hit.cursor = Some(sabitori_core::Cursor::Pointer);
+        }
+
         // Feed tooltip state
-        {
-            let id_ref = new_hovered.as_deref();
-            let tt_ref = tooltip_text.as_deref();
-            self.tooltip_state.on_hover_change(id_ref, tt_ref, self.mouse_x, self.mouse_y);
+        self.tooltip_state.on_hover_change(
+            hit.hovered_id.as_deref(),
+            hit.tooltip.as_deref(),
+            self.mouse_x,
+            self.mouse_y,
+        );
+        if self.hovered_id != hit.hovered_id {
+            self.app.on_hover_change(hit.hovered_id.as_deref());
         }
-        if self.hovered_id != new_hovered {
-            self.app.on_hover_change(new_hovered.as_deref());
-        }
-        self.hovered_id = new_hovered;
-        self.apply_cursor(hover_cursor);
+        self.hovered_id = hit.hovered_id;
+        self.apply_cursor(hit.cursor);
         self.push_ui_capture();
     }
 
@@ -2755,43 +2733,22 @@ impl<A: DeclarativeApp> AppState<A> {
     /// scene-hosting app always has a current view of "does the UI want
     /// this input?" before the next raw event arrives.
     fn push_ui_capture(&mut self) {
-        let wants_pointer = self
-            .last_build
-            .as_ref()
-            .map(|b| b.wants_pointer(self.mouse_x, self.mouse_y))
-            .unwrap_or(false)
-            || self.drag_manager.is_active();
-        let capture = UiCapture {
-            wants_pointer,
-            wants_keyboard: self.focused_id.is_some(),
-        };
-        if capture != self.last_capture {
-            self.last_capture = capture;
-            self.app.on_ui_capture(capture);
-        }
+        crate::runtime_shared::push_ui_capture(
+            self.last_build.as_ref(),
+            self.mouse_x,
+            self.mouse_y,
+            self.drag_manager.is_active(),
+            self.focused_id.is_some(),
+            &mut self.last_capture,
+            &mut self.app,
+        );
     }
 
-    /// Push the resolved cursor preference to the OS via winit. `None`
-    /// resolves to `Cursor::Default` (the platform arrow). Deduped
-    /// against `last_cursor` so we don't fire a `set_cursor` every
-    /// pointer-move event.
+    /// 解決した cursor を OS へ送る。 dedup も winit へのマッピングも
+    /// [`crate::runtime_shared::apply_cursor`] に集約 — マッピング表が 2 つあると、
+    /// `Cursor` に variant を足した時に片方だけ忘れられる。
     fn apply_cursor(&mut self, cursor: Option<sabitori_core::Cursor>) {
-        let resolved = cursor.unwrap_or(sabitori_core::Cursor::Default);
-        if self.last_cursor == Some(resolved) {
-            return;
-        }
-        self.last_cursor = Some(resolved);
-        if let Some(window) = self.window.as_ref() {
-            let icon = match resolved {
-                sabitori_core::Cursor::Default => winit::window::CursorIcon::Default,
-                sabitori_core::Cursor::Pointer => winit::window::CursorIcon::Pointer,
-                sabitori_core::Cursor::Text => winit::window::CursorIcon::Text,
-                sabitori_core::Cursor::Crosshair => winit::window::CursorIcon::Crosshair,
-                sabitori_core::Cursor::NotAllowed => winit::window::CursorIcon::NotAllowed,
-                sabitori_core::Cursor::ResizeEw => winit::window::CursorIcon::EwResize,
-            };
-            window.set_cursor(icon);
-        }
+        crate::runtime_shared::apply_cursor(self.window.as_ref(), &mut self.last_cursor, cursor);
     }
 
     /// Dispatch winit events for an extra window. v1 only acts on the

--- a/crates/sabitori/src/lib.rs
+++ b/crates/sabitori/src/lib.rs
@@ -27,6 +27,8 @@ pub use sabitori_window::{SabitoriApp, EmbeddedRunner, run};
 pub mod bridge;
 pub mod declarative;
 pub mod scroll_sync;
+// 2 ランタイム (declarative / scene) が共有するポインタ解決。 crate 内部専用。
+mod runtime_shared;
 pub mod slider_sync;
 pub mod image_runtime;
 pub(crate) mod input_router;

--- a/crates/sabitori/src/runtime_shared.rs
+++ b/crates/sabitori/src/runtime_shared.rs
@@ -1,0 +1,222 @@
+//! `DeclarativeApp` と `SceneApp` の 2 ランタイムが共有する、ポインタまわりの
+//! 解決ロジック。
+//!
+//! 両ランタイムは winit のイベントループを別々に回すので `ApplicationHandler` の
+//! 実装は分かれる。 だが「hit_regions からホバーを引く」「押下対象を引く」
+//! 「cursor を winit に送る」「入力キャプチャを算出する」は、どちらで動かしても
+//! **同じ答えでなければならない**。
+//!
+//! かつては scene_app 側に "ported verbatim so both runtimes resolve hover
+//! identically" と注記された複製が置かれていた。 注記があっても複製は複製で、
+//! 実際 `active_style` の対応は declarative にだけ入りかけている
+//! ([#3](https://github.com/Mutafika/sabitori/issues/3))。 同じ理由で `Cursor` に
+//! variant を足す時、 winit へのマッピング表が 2 つあれば片方は必ず忘れられる。
+//!
+//! 状態 (hovered_id / last_cursor / window / …) は各ランタイムが持ったまま、
+//! **判断だけ**をここに集める。 引数が素の値なので、 winit のウィンドウ無しに
+//! テストから叩ける。
+
+use std::sync::Arc;
+
+use sabitori_core::build::BuildResult;
+use sabitori_core::{Cursor, Point};
+use winit::window::Window;
+
+use crate::declarative::{DeclarativeApp, UiCapture};
+
+/// ポインタ直下のホバー解決結果。
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct HoverHit {
+    /// ホバー中の要素 id。
+    pub hovered_id: Option<String>,
+    /// その要素の tooltip。
+    pub tooltip: Option<String>,
+    /// 効かせるべき cursor。 `None` = 誰も指定していない (= 既定の矢印)。
+    pub cursor: Option<Cursor>,
+}
+
+/// `hit_regions` からポインタ直下のホバー情報を引く。
+///
+/// ホバー判定と cursor 判定は**独立**に走る。 hoverable でない領域でも cursor は
+/// 主張できる (テキスト入力が `Cursor::Text` を出す等) ので、 cursor は全領域を
+/// 前面から舐めて最初に指定のあるものを採る。
+pub(crate) fn resolve_hover(build: &BuildResult, x: f32, y: f32) -> HoverHit {
+    let pt = Point::new(x, y);
+    let hover_match = build
+        .hit_regions
+        .iter()
+        .find(|r| r.hoverable && r.rect.contains(pt));
+    let (hovered_id, tooltip) = match hover_match {
+        Some(r) => (r.id.clone(), r.tooltip.clone()),
+        None => (None, None),
+    };
+    let cursor = build
+        .hit_regions
+        .iter()
+        .find(|r| r.cursor.is_some() && r.rect.contains(pt))
+        .and_then(|r| r.cursor);
+    HoverHit { hovered_id, tooltip, cursor }
+}
+
+/// 座標の下にある、 id を持つ最前面の hit region の id。 押下対象の解決に使う。
+///
+/// ホバーと違って `hoverable` では絞らない — `.active()` だけを書いた要素
+/// (hover_style を持たない) も押下対象になるべきなので、 `clickable`
+/// (= id 付き) で見る。
+pub(crate) fn hit_id_at(build: &BuildResult, x: f32, y: f32) -> Option<String> {
+    let pt = Point::new(x, y);
+    build
+        .hit_regions
+        .iter()
+        .find(|r| r.clickable && r.id.is_some() && r.rect.contains(pt))
+        .and_then(|r| r.id.clone())
+}
+
+/// `Cursor` を winit の `CursorIcon` へ。
+///
+/// **マッピング表はここ 1 つだけ**にすること。 variant を足した時に片方の
+/// ランタイムだけ更新される、が起きなくなる。
+pub(crate) fn winit_cursor(cursor: Cursor) -> winit::window::CursorIcon {
+    use winit::window::CursorIcon;
+    match cursor {
+        Cursor::Default => CursorIcon::Default,
+        Cursor::Pointer => CursorIcon::Pointer,
+        Cursor::Text => CursorIcon::Text,
+        Cursor::Crosshair => CursorIcon::Crosshair,
+        Cursor::NotAllowed => CursorIcon::NotAllowed,
+        Cursor::ResizeEw => CursorIcon::EwResize,
+    }
+}
+
+/// 解決した cursor を OS へ送る。 `None` は既定の矢印になる。
+///
+/// `last` と突き合わせて重複呼び出しを潰す — ポインタ移動のたびに `set_cursor`
+/// を叩くのは只ではなく、 macOS の NSCursor 差し替えは視覚的なちらつきとして
+/// 出ることがある。
+pub(crate) fn apply_cursor(
+    window: Option<&Arc<Window>>,
+    last: &mut Option<Cursor>,
+    cursor: Option<Cursor>,
+) {
+    let resolved = cursor.unwrap_or(Cursor::Default);
+    if *last == Some(resolved) {
+        return;
+    }
+    *last = Some(resolved);
+    if let Some(window) = window {
+        window.set_cursor(winit_cursor(resolved));
+    }
+}
+
+/// 今フレームの入力キャプチャ状態。 ホスト (埋め込み側) が「この座標の入力は
+/// sabitori が食う」を判断するのに使う。
+pub(crate) fn ui_capture(
+    build: Option<&BuildResult>,
+    x: f32,
+    y: f32,
+    drag_active: bool,
+    focused: bool,
+) -> UiCapture {
+    let wants_pointer = build.map(|b| b.wants_pointer(x, y)).unwrap_or(false) || drag_active;
+    UiCapture { wants_pointer, wants_keyboard: focused }
+}
+
+/// [`ui_capture`] を算出し、 前回から変わっていればアプリへ通知する。
+pub(crate) fn push_ui_capture<A: DeclarativeApp>(
+    build: Option<&BuildResult>,
+    x: f32,
+    y: f32,
+    drag_active: bool,
+    focused: bool,
+    last: &mut UiCapture,
+    app: &mut A,
+) {
+    let capture = ui_capture(build, x, y, drag_active, focused);
+    if capture != *last {
+        *last = capture;
+        app.on_ui_capture(capture);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sabitori_core::element::{div, Px};
+
+    fn build(root: &sabitori_core::Element) -> BuildResult {
+        sabitori_core::build::build_tree(root, 400.0, 300.0)
+    }
+
+    /// ホバーと cursor は独立に引く。 hoverable でない領域が cursor を主張して
+    /// いれば、 ホバー対象にならなくても cursor は効く。
+    ///
+    /// `on_click` だけを持つ要素は clickable だが hoverable ではないので、
+    /// 両者が別経路であることがそのまま出る。
+    #[test]
+    fn cursor_is_resolved_independently_of_hover() {
+        let root = div().child(
+            div()
+                .w(Px(100.0))
+                .h(Px(50.0))
+                .on_click(|| {})
+                .cursor(Cursor::Crosshair),
+        );
+        let b = build(&root);
+        let hit = resolve_hover(&b, 10.0, 10.0);
+
+        assert_eq!(hit.hovered_id, None, "hoverable ではないので hover 対象ではない");
+        assert_eq!(hit.cursor, Some(Cursor::Crosshair), "cursor だけは効く");
+    }
+
+    /// 押下対象は `hoverable` では絞らない — `.active()` だけを書いた要素も掴む。
+    #[test]
+    fn press_target_does_not_require_hoverability() {
+        let root = div().child(div().id("btn").w(Px(100.0)).h(Px(50.0)));
+        let b = build(&root);
+
+        assert_eq!(hit_id_at(&b, 10.0, 10.0).as_deref(), Some("btn"));
+        assert_eq!(hit_id_at(&b, 300.0, 200.0), None, "外は掴まない");
+    }
+
+    /// `Cursor` の全 variant が winit に写せること。 variant を足してここが
+    /// 落ちたら、 マッピングの更新漏れ。
+    #[test]
+    fn every_cursor_variant_maps_to_winit() {
+        use winit::window::CursorIcon;
+        let pairs = [
+            (Cursor::Default, CursorIcon::Default),
+            (Cursor::Pointer, CursorIcon::Pointer),
+            (Cursor::Text, CursorIcon::Text),
+            (Cursor::Crosshair, CursorIcon::Crosshair),
+            (Cursor::NotAllowed, CursorIcon::NotAllowed),
+            (Cursor::ResizeEw, CursorIcon::EwResize),
+        ];
+        for (from, to) in pairs {
+            assert_eq!(winit_cursor(from), to, "{from:?} のマッピングが違う");
+        }
+    }
+
+    /// 同じ cursor を続けて送っても、 OS へは 1 回しか行かない。
+    #[test]
+    fn repeated_cursors_are_deduped() {
+        let mut last = None;
+        apply_cursor(None, &mut last, Some(Cursor::Text));
+        assert_eq!(last, Some(Cursor::Text));
+        // 2 回目は素通り (window が None なので副作用は観測できないが、
+        // last が書き換わらないことで dedup の分岐を通ったと分かる)。
+        apply_cursor(None, &mut last, Some(Cursor::Text));
+        assert_eq!(last, Some(Cursor::Text));
+        // None は既定の矢印として扱う。
+        apply_cursor(None, &mut last, None);
+        assert_eq!(last, Some(Cursor::Default));
+    }
+
+    /// ドラッグ中はポインタが要素の上に無くてもキャプチャする。
+    #[test]
+    fn an_active_drag_captures_the_pointer() {
+        let b = build(&div());
+        assert!(!ui_capture(Some(&b), 5.0, 5.0, false, false).wants_pointer);
+        assert!(ui_capture(Some(&b), 5.0, 5.0, true, false).wants_pointer);
+        assert!(ui_capture(None, 5.0, 5.0, false, true).wants_keyboard);
+    }
+}

--- a/crates/sabitori/src/scene_app.rs
+++ b/crates/sabitori/src/scene_app.rs
@@ -112,93 +112,58 @@ struct SceneAppState<A: SceneApp> {
 }
 
 impl<A: SceneApp> SceneAppState<A> {
+    /// ポインタ直下のホバー / tooltip / cursor を引き直し、変化をアプリへ通知する。
+    /// 解決そのものは [`crate::runtime_shared::resolve_hover`] — declarative と
+    /// 同じ関数を呼ぶ。
     fn update_hover(&mut self) {
-        // Hover lookup (closest hoverable region) and cursor lookup are
-        // independent: a non-hoverable region can still declare a cursor
-        // (e.g. a text input asking for `Cursor::Text`). Mirrors the
-        // declarative `AppState::update_hover`.
-        let (new_hovered, hover_cursor, tooltip_text) = if let Some(ref build) = self.last_build {
-            let pt = sabitori_core::Point::new(self.mouse_x, self.mouse_y);
-            let hover_match = build.hit_regions.iter()
-                .find(|r| r.hoverable && r.rect.contains(pt));
-            let (hovered, tooltip) = match hover_match {
-                Some(r) => (r.id.clone(), r.tooltip.clone()),
-                None => (None, None),
-            };
-            let cursor = build.hit_regions.iter()
-                .find(|r| r.cursor.is_some() && r.rect.contains(pt))
-                .and_then(|r| r.cursor);
-            (hovered, cursor, tooltip)
-        } else {
-            (None, None, None)
-        };
-        // Feed the tooltip hover-delay state machine (same as declarative).
-        {
-            let id_ref = new_hovered.as_deref();
-            let tt_ref = tooltip_text.as_deref();
-            self.tooltip_state.on_hover_change(id_ref, tt_ref, self.mouse_x, self.mouse_y);
+        let hit = self
+            .last_build
+            .as_ref()
+            .map(|b| crate::runtime_shared::resolve_hover(b, self.mouse_x, self.mouse_y))
+            .unwrap_or_default();
+        // 本文中リンクの上書きは declarative 側にしかない (こちらにテキスト選択層が
+        // 無いため)。 それ以外は同じ経路を通る。
+        self.tooltip_state.on_hover_change(
+            hit.hovered_id.as_deref(),
+            hit.tooltip.as_deref(),
+            self.mouse_x,
+            self.mouse_y,
+        );
+        if self.hovered_id != hit.hovered_id {
+            self.app.on_hover_change(hit.hovered_id.as_deref());
         }
-        if self.hovered_id != new_hovered {
-            self.app.on_hover_change(new_hovered.as_deref());
-        }
-        self.hovered_id = new_hovered;
-        self.apply_cursor(hover_cursor);
+        self.hovered_id = hit.hovered_id;
+        self.apply_cursor(hit.cursor);
         self.push_ui_capture();
     }
 
-    /// Push the resolved cursor preference to the OS via winit. `None`
-    /// resolves to the platform arrow. Deduped against `last_cursor` so we
-    /// don't fire `set_cursor` on every pointer-move. Ported verbatim from
-    /// the declarative `AppState` so both runtimes map cursors identically.
+    /// 解決した cursor を OS へ送る。 実体は
+    /// [`crate::runtime_shared::apply_cursor`] — declarative と同じ関数を呼ぶので、
+    /// 2 ランタイムの cursor 解決は定義上一致する（かつては "ported verbatim" の
+    /// 複製で、一致は口約束だった）。
     fn apply_cursor(&mut self, cursor: Option<sabitori_core::Cursor>) {
-        let resolved = cursor.unwrap_or(sabitori_core::Cursor::Default);
-        if self.last_cursor == Some(resolved) {
-            return;
-        }
-        self.last_cursor = Some(resolved);
-        if let Some(window) = self.window.as_ref() {
-            let icon = match resolved {
-                sabitori_core::Cursor::Default => winit::window::CursorIcon::Default,
-                sabitori_core::Cursor::Pointer => winit::window::CursorIcon::Pointer,
-                sabitori_core::Cursor::Text => winit::window::CursorIcon::Text,
-                sabitori_core::Cursor::Crosshair => winit::window::CursorIcon::Crosshair,
-                sabitori_core::Cursor::NotAllowed => winit::window::CursorIcon::NotAllowed,
-                sabitori_core::Cursor::ResizeEw => winit::window::CursorIcon::EwResize,
-            };
-            window.set_cursor(icon);
-        }
+        crate::runtime_shared::apply_cursor(self.window.as_ref(), &mut self.last_cursor, cursor);
     }
 
-    /// 座標の下にある、id を持つ最前面の hit region の id。押下対象の解決に使う。
-    /// declarative の `AppState::hit_id_at` と同じ引き方。
+    /// 押下対象の解決。 実体は [`crate::runtime_shared::hit_id_at`]。
     fn hit_id_at(&self, x: f32, y: f32) -> Option<String> {
         let build = self.last_build.as_ref()?;
-        let pt = sabitori_core::Point::new(x, y);
-        build
-            .hit_regions
-            .iter()
-            .find(|r| r.clickable && r.id.is_some() && r.rect.contains(pt))
-            .and_then(|r| r.id.clone())
+        crate::runtime_shared::hit_id_at(build, x, y)
     }
 
     /// Recompute the [`UiCapture`] snapshot and push it to the app when it
     /// changed. SceneApp hosts gate their camera / scene input on this —
     /// the egui `wants_pointer_input()` / `wants_keyboard_input()` pattern.
     fn push_ui_capture(&mut self) {
-        let wants_pointer = self
-            .last_build
-            .as_ref()
-            .map(|b| b.wants_pointer(self.mouse_x, self.mouse_y))
-            .unwrap_or(false)
-            || self.drag_manager.is_active();
-        let capture = UiCapture {
-            wants_pointer,
-            wants_keyboard: self.focused_id.is_some(),
-        };
-        if capture != self.last_capture {
-            self.last_capture = capture;
-            self.app.on_ui_capture(capture);
-        }
+        crate::runtime_shared::push_ui_capture(
+            self.last_build.as_ref(),
+            self.mouse_x,
+            self.mouse_y,
+            self.drag_manager.is_active(),
+            self.focused_id.is_some(),
+            &mut self.last_capture,
+            &mut self.app,
+        );
     }
 
     fn winit_to_sabi_button(button: winit::event::MouseButton) -> Option<SabiMouseButton> {


### PR DESCRIPTION
`declarative` と `scene` の 2 ランタイムは、**ポインタまわりの判断を手で複製**していた。
scene 側には

> Ported verbatim from the declarative `AppState` so both runtimes map cursors identically.

という注記まで付いていたが、注記があっても複製は複製で、実際 #3 の `active_style` 対応は
declarative にだけ入りかけている（同じ穴が scene にも空いていた）。`Cursor` に variant を
足す時も、マッピング表が 2 つあれば片方は必ず忘れられる。

## やったこと

状態（`hovered_id` / `last_cursor` / `window` / …）は各ランタイムが持ったまま、
**判断だけ**を crate 内部の `runtime_shared` モジュールへ移した。

| 関数 | 中身 |
|---|---|
| `resolve_hover` | ホバー / tooltip / cursor の解決（cursor は hover と独立に引く） |
| `hit_id_at` | 押下対象（`clickable` かつ id 付きの最前面） |
| `winit_cursor` | `Cursor` → `CursorIcon` のマッピング表。**これ 1 つだけ** |
| `apply_cursor` | dedup 込みで OS へ送る |
| `ui_capture` / `push_ui_capture` | 入力キャプチャの算出と通知 |

引数が素の値なので、winit のウィンドウ無しにテストから叩ける。

## 挙動は変えていない

4 つのうち `apply_cursor` / `push_ui_capture` / `hit_id_at` は元から**完全一致**していた。
`update_hover` だけ差があり、それは declarative が本文中リンクで上書きする分（scene 側に
テキスト選択層が無い）。その差はそのまま残し、**2 ランタイムの唯一の差**であることを
コメントで明示した。

公開 API は変わらない（`mod runtime_shared` は private）。

## テスト

新規 5 本。いずれも winit 不要。

- cursor はホバーと独立に解決される（`on_click` だけを持つ要素は clickable だが
  hoverable ではない、という組み合わせで経路の独立を示す）
- 押下対象は `hoverable` では絞らない（`.active()` だけを書いた要素も掴む）
- **`Cursor` の全 variant が winit に写せる** — variant を足してここが落ちたら更新漏れ
- 同じ cursor の連続送信は dedup される
- ドラッグ中はポインタが要素の上に無くてもキャプチャする

`cargo test --workspace` green。

## 差し引き

2 ファイルから正味 75 行減り、共有モジュール 222 行（うち約 90 行がテスト）が増えた。

## リリースについて

公開 API も挙動も変わらない内部整理なので、CHANGELOG への記載とバージョン bump は
していない（`RELEASING.md` の「書くことが無いなら、そもそも上げる必要が無い」に従う）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)