### PR TITLE
入力イベントの配線漏れをコンパイルエラーで止める (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,60 @@
 
 ## [Unreleased]
 
+次の版は **0.4.0**。フレームワーク全体を見直して挙げた
+[#14〜#22](https://github.com/Mutafika/sabitori/issues) を潰す破壊的変更ラウンド。
+旧 API は `#[deprecated]` を挟まず削除し、代わりに移行手順をここに残す方針。
+
+### Added
+- **入力イベントの配線漏れをコンパイルエラーで止める仕組み**
+  ([#17](https://github.com/Mutafika/sabitori/issues/17))。
+
+  sabitori はイベント処理を共有しない 3 つのランタイム（`DeclarativeApp` /
+  `SceneApp` / `SabitoriApp`）を持ち、配線は 1 つずつ手で書かれている。その結果
+  「core は持っているのにランタイムが配らない」事故が繰り返し起きていた
+  （[#1](https://github.com/Mutafika/sabitori/issues/1) /
+  [#3](https://github.com/Mutafika/sabitori/issues/3) /
+  [#12](https://github.com/Mutafika/sabitori/issues/12)）。#12 に至っては、その修正作業の
+  中で `sabitori-window` が新 variant を `_ => {}` で握り潰す**同型のバグを作っている**。
+
+  - **`InputEventKind`** — `InputEvent` からペイロードを落とした種別。値を持たないので
+    `match` の腕として並べられる。`InputEventKind::ALL` で全種別を舐められる。
+  - **`InputEvent::kind()`** — 「全 variant を知っている唯一の場所」。`InputEvent` に
+    variant を足すとまずここが壊れる。
+  - **`Delivery`** — 1 種別をアプリへどう扱うかの宣言。`ToApp` / `FocusedOnly` /
+    `Internal(理由)` / `NotProduced(理由)`。
+  - **`input_delivery(kind) -> Delivery`** — 3 ランタイムそれぞれに追加。
+    `sabitori::declarative` / `sabitori::scene_app` / `sabitori_window` の各モジュール。
+    `InputEventKind` に対する**網羅マッチ**なので、種別が増えると 3 つとも
+    コンパイルエラーになり、「配る / 内部で消費する / 発行しない」の判断を必ず通る。
+
+  検証済み: `InputEvent` に variant を 1 つ足すと**計 6 箇所**（`kind()`、
+  `sabitori-window` の配信表とポインタ match 2 つ、`declarative` と `scene_app` の
+  配信表）がコンパイルエラーになる。
+
+  宣言はドキュメントでもある。「このランタイムで `InputEvent::ImeEnabled` は来るのか」
+  を表 1 つで確認できる。実際にこの作業でランタイム間の差が 2 件見つかっており、
+  事実として宣言に書き出したうえで
+  [#22](https://github.com/Mutafika/sabitori/issues/22) に切り出した。
+
+### Fixed
+- **`sabitori-window` のポインタ `match` が網羅でなかった**
+  ([#17](https://github.com/Mutafika/sabitori/issues/17))。`process_event` /
+  `inject_event` の `_ => {}` を廃止し、無視する種別も明示的に並べた。#12 で
+  `ModifiersChanged` が app へ一度も届かなかったのがこの穴で、当時はマージ前
+  レビューでしか捕まらなかった。
+
+- **`EmbeddedRunner::inject_event` が `PointerCancelled` を処理していなかった**
+  ([#17](https://github.com/Mutafika/sabitori/issues/17))。`process_event` 側には
+  最初からある腕が注入経路には無く、`_ => {}` が隠していた。ホストが cancel を
+  注入すると押下ノードが解除されず、**以後ずっと押されたまま**になる。網羅マッチに
+  した結果あらわれた実バグ。
+
+### 移行
+
+破壊的変更なし。`sabitori::*` の glob に `Delivery` / `InputEventKind` が増えるので、
+下流に同名の型があれば衝突する（その場合は明示 import で回避）。
+
 ## [0.3.21] - 2026-08-12
 
 修飾キーの変化を観測できるようにした版。「⇧を押している間だけ」効かせる操作

--- a/crates/sabitori-input/src/lib.rs
+++ b/crates/sabitori-input/src/lib.rs
@@ -169,6 +169,122 @@ pub enum InputEvent {
     CharInput(char),
 }
 
+/// [`InputEvent`] からペイロードを落とした種別。
+///
+/// 値を持たないので `match` の腕として並べられる。 「どのランタイムがどの種類を
+/// アプリへ配るか」 を [`Delivery`] の表で宣言するために要る。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum InputEventKind {
+    PointerMoved,
+    PointerPressed,
+    PointerReleased,
+    PointerCancelled,
+    PointerLeft,
+    ImeEnabled,
+    ImePreedit,
+    ImeCommit,
+    KeyInput,
+    ModifiersChanged,
+    CharInput,
+}
+
+impl InputEventKind {
+    /// 全種別。 [`Delivery`] の表をテストが舐めるのに使う。
+    ///
+    /// 更新漏れは下の `all_lists_every_kind` が落とす — [`Self::order`] が網羅
+    /// マッチなので、 variant を足すとまず**コンパイルが壊れ**、 番号を振ると
+    /// 今度は `ALL` に入れるまで**テストが落ちる**。 2 段で塞いである。
+    pub const ALL: &'static [InputEventKind] = &[
+        InputEventKind::PointerMoved,
+        InputEventKind::PointerPressed,
+        InputEventKind::PointerReleased,
+        InputEventKind::PointerCancelled,
+        InputEventKind::PointerLeft,
+        InputEventKind::ImeEnabled,
+        InputEventKind::ImePreedit,
+        InputEventKind::ImeCommit,
+        InputEventKind::KeyInput,
+        InputEventKind::ModifiersChanged,
+        InputEventKind::CharInput,
+    ];
+
+    /// [`Self::ALL`] 内で占めるべき位置。 `ALL` の完全性検査にだけ使うので
+    /// テストビルド限定。 種別追加をコンパイルで止める役目は [`InputEvent::kind`]
+    /// が通常ビルドで担っており、 こちらはその後の「`ALL` 更新漏れ」だけを見る。
+    #[cfg(test)]
+    fn order(self) -> usize {
+        match self {
+            InputEventKind::PointerMoved => 0,
+            InputEventKind::PointerPressed => 1,
+            InputEventKind::PointerReleased => 2,
+            InputEventKind::PointerCancelled => 3,
+            InputEventKind::PointerLeft => 4,
+            InputEventKind::ImeEnabled => 5,
+            InputEventKind::ImePreedit => 6,
+            InputEventKind::ImeCommit => 7,
+            InputEventKind::KeyInput => 8,
+            InputEventKind::ModifiersChanged => 9,
+            InputEventKind::CharInput => 10,
+        }
+    }
+}
+
+impl InputEvent {
+    /// 種別だけを取り出す。
+    ///
+    /// **`InputEvent` に variant を足すとこの `match` が壊れる。** それが狙いで、
+    /// ここが「全 variant を知っている唯一の場所」。 壊れたら
+    /// [`InputEventKind`] に対応する種別を足すことになり、 その結果 3 つの
+    /// ランタイムの `input_delivery` (これも網羅マッチ) が軒並みコンパイル
+    /// エラーになる。 新しい入力が「どこかのランタイムだけ配線されない」状態で
+    /// merge されるのを、 レビューではなく型で止める。
+    pub fn kind(&self) -> InputEventKind {
+        match self {
+            InputEvent::PointerMoved { .. } => InputEventKind::PointerMoved,
+            InputEvent::PointerPressed { .. } => InputEventKind::PointerPressed,
+            InputEvent::PointerReleased { .. } => InputEventKind::PointerReleased,
+            InputEvent::PointerCancelled { .. } => InputEventKind::PointerCancelled,
+            InputEvent::PointerLeft => InputEventKind::PointerLeft,
+            InputEvent::ImeEnabled => InputEventKind::ImeEnabled,
+            InputEvent::ImePreedit { .. } => InputEventKind::ImePreedit,
+            InputEvent::ImeCommit { .. } => InputEventKind::ImeCommit,
+            InputEvent::KeyInput { .. } => InputEventKind::KeyInput,
+            InputEvent::ModifiersChanged(_) => InputEventKind::ModifiersChanged,
+            InputEvent::CharInput(_) => InputEventKind::CharInput,
+        }
+    }
+}
+
+/// あるランタイムが [`InputEventKind`] の 1 種別をどう扱うかの宣言。
+///
+/// sabitori にはイベント処理を共有しない 3 つのランタイム (`DeclarativeApp` /
+/// `SceneApp` / `SabitoriApp`) があり、 配線は 1 つずつ手で書かれている。 その結果
+/// 「core は持っているのにランタイムが配らない」 事故が繰り返し起きた
+/// (issue #1 / #3 / #12)。 #12 に至っては、 修正作業そのものの中で
+/// `sabitori-window` が新 variant を `_ => {}` で握り潰す同型のバグを作っている。
+///
+/// そこで各ランタイムは全種別についてこの型で意思表示する。 宣言は
+/// [`InputEventKind`] に対する**網羅マッチ**なので、 種別が増えると 3 ランタイム
+/// 全部がコンパイルエラーになり、 「配る / 内部で消費する / 発行しない」 の判断を
+/// 必ず通ることになる。
+///
+/// 宣言はドキュメントでもある — 消費側は「このランタイムで
+/// `InputEvent::ImeEnabled` は来るのか」 を表 1 つで確認できる。
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Delivery {
+    /// `on_input` でアプリに届く。 フォーカス中の要素があれば
+    /// `on_focused_input` を先に試し、 消費されなければ `on_input` へ落ちる。
+    ToApp,
+    /// `on_focused_input` に**だけ**届く。 フォーカス中の要素が無いときは
+    /// どこにも届かないので、 グローバルに観測したい用途には使えない。
+    FocusedOnly,
+    /// ランタイムが内部で消費する。 文字列はアプリ側へ伝わる別の口の名前
+    /// (`"on_click"` など)。 生のイベントは届かない。
+    Internal(&'static str),
+    /// このランタイムでは発行されない。 文字列は理由。
+    NotProduced(&'static str),
+}
+
 /// Per-node interaction state.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct InteractionState {
@@ -224,5 +340,86 @@ impl PointerState {
             .iter()
             .position(|p| p.id == id)
             .map(|i| self.active.remove(i))
+    }
+}
+
+#[cfg(test)]
+mod kind_tests {
+    use super::*;
+    use sabitori_core::Point;
+
+    /// `InputEventKind::ALL` に載せ忘れた種別を落とす。
+    ///
+    /// `order()` が網羅マッチなので variant 追加はまずコンパイルで止まるが、
+    /// そこで番号を振っただけで `ALL` を更新し忘れる経路が残る。 それをここで塞ぐ。
+    #[test]
+    fn all_lists_every_kind() {
+        for (i, k) in InputEventKind::ALL.iter().enumerate() {
+            assert_eq!(
+                k.order(),
+                i,
+                "ALL の並びが order() と食い違っている: {k:?} は {} 番のはず",
+                k.order()
+            );
+        }
+        // order() に振った最大番号 + 1 = ALL の長さ。 新種別に番号を振ったのに
+        // ALL へ入れ忘れると、 ここが落ちる。
+        let max_order = InputEventKind::ALL.iter().map(|k| k.order()).max().unwrap();
+        assert_eq!(
+            InputEventKind::ALL.len(),
+            max_order + 1,
+            "order() に番号を振った種別が ALL に入っていない"
+        );
+    }
+
+    /// `kind()` が各 variant を正しい種別に落とすこと。
+    #[test]
+    fn kind_maps_each_variant() {
+        let at = Point::new(0.0, 0.0);
+        let m = Modifiers::default();
+        let cases: &[(InputEvent, InputEventKind)] = &[
+            (
+                InputEvent::PointerMoved { id: MOUSE_POINTER_ID, kind: PointerKind::Mouse, position: at, modifiers: m },
+                InputEventKind::PointerMoved,
+            ),
+            (
+                InputEvent::PointerPressed { id: MOUSE_POINTER_ID, kind: PointerKind::Mouse, position: at, button: Some(MouseButton::Left), modifiers: m },
+                InputEventKind::PointerPressed,
+            ),
+            (
+                InputEvent::PointerReleased { id: MOUSE_POINTER_ID, kind: PointerKind::Mouse, position: at, button: Some(MouseButton::Left), modifiers: m },
+                InputEventKind::PointerReleased,
+            ),
+            (
+                InputEvent::PointerCancelled { id: 1, kind: PointerKind::Touch },
+                InputEventKind::PointerCancelled,
+            ),
+            (InputEvent::PointerLeft, InputEventKind::PointerLeft),
+            (InputEvent::ImeEnabled, InputEventKind::ImeEnabled),
+            (
+                InputEvent::ImePreedit { text: "かな".into(), cursor: None },
+                InputEventKind::ImePreedit,
+            ),
+            (
+                InputEvent::ImeCommit { text: "仮名".into() },
+                InputEventKind::ImeCommit,
+            ),
+            (
+                InputEvent::KeyInput { key: Key::A, pressed: true, modifiers: m },
+                InputEventKind::KeyInput,
+            ),
+            (InputEvent::ModifiersChanged(m), InputEventKind::ModifiersChanged),
+            (InputEvent::CharInput('あ'), InputEventKind::CharInput),
+        ];
+        for (event, expected) in cases {
+            assert_eq!(event.kind(), *expected, "{event:?} の kind() が違う");
+        }
+        // 全種別を 1 度ずつ網羅していること (テスト自体の抜けを防ぐ)。
+        for k in InputEventKind::ALL {
+            assert!(
+                cases.iter().any(|(_, got)| got == k),
+                "{k:?} のケースがこのテストに無い"
+            );
+        }
     }
 }

--- a/crates/sabitori-window/src/lib.rs
+++ b/crates/sabitori-window/src/lib.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use sabitori_core::Point;
 use sabitori_gpu::{GpuRenderer, RectInstance};
 use sabitori_input::{
-    button_bit, ActivePointer, BUTTON_PRIMARY, InputEvent, MouseButton,
+    button_bit, ActivePointer, BUTTON_PRIMARY, Delivery, InputEvent, InputEventKind, MouseButton,
     PointerKind, PointerState, MOUSE_POINTER_ID,
 };
 use sabitori_scene::{NodeId, NodeTree};
@@ -33,6 +33,37 @@ pub trait SabitoriApp {
     /// Return `true` if the event was handled (consumed).
     fn on_input(&mut self, _event: &InputEvent) -> bool {
         false
+    }
+}
+
+/// このランタイムが [`InputEvent`] の各種別をアプリへどう届けるかの宣言。
+///
+/// 他の 2 つ (`sabitori::declarative::input_delivery` /
+/// `sabitori::scene_app::input_delivery`) と大きく違い、 **ポインタ系は 1 つも
+/// アプリに届かない**。 `NodeTree` が hit-test と押下追跡を内部で行い、 結果だけを
+/// [`SabitoriApp::on_click`] で伝える retained なモデルだから。
+///
+/// [`Delivery`] の doc にある通り、 これは [`InputEventKind`] に対する網羅マッチ
+/// なので、 種別が増えるとここがコンパイルエラーになる。 issue #12 では
+/// `ModifiersChanged` がこのランタイムの `_ => {}` に落ちて app へ一度も届かず、
+/// マージ前レビューでしか捕まらなかった。 その経路を型で塞ぐのがこの宣言の目的。
+pub fn input_delivery(kind: InputEventKind) -> Delivery {
+    match kind {
+        InputEventKind::PointerMoved => {
+            Delivery::Internal("NodeTree の hover 更新と押下ノードの追跡")
+        }
+        InputEventKind::PointerPressed | InputEventKind::PointerReleased => {
+            Delivery::Internal("NodeTree の押下追跡 → SabitoriApp::on_click")
+        }
+        InputEventKind::PointerCancelled => Delivery::Internal("押下ノードの解除"),
+        InputEventKind::PointerLeft => Delivery::Internal("hover の解除とカーソル復帰"),
+
+        InputEventKind::ImeEnabled
+        | InputEventKind::ImePreedit
+        | InputEventKind::ImeCommit
+        | InputEventKind::KeyInput
+        | InputEventKind::CharInput
+        | InputEventKind::ModifiersChanged => Delivery::ToApp,
     }
 }
 
@@ -539,7 +570,25 @@ impl<A: SabitoriApp> AppState<A> {
                     window.set_cursor(CursorIcon::Default);
                 }
             }
-            _ => {}
+
+            // --- ここから下は上の match が `return` 済み ---
+            //
+            // ワイルドカードで畳まないのが要点。 `_ => {}` にしていたせいで、
+            // `InputEvent` に足したばかりの `ModifiersChanged` が上の
+            // キーボード群にも入らずここにも落ちて、 app へ一度も届かなかった
+            // (issue #12)。 網羅マッチにしてあれば、 種別を足した人はここで
+            // コンパイルエラーに当たり、 上のキーボード群に入れるか
+            // ポインタとして処理するかを選ばされる。
+            //
+            // 押下・移動が非 primary (右/中ボタン) の場合もガード付きの腕から
+            // 漏れてここに来る。 このランタイムは primary しか見ないので no-op。
+            InputEvent::PointerPressed { .. } | InputEvent::PointerReleased { .. } => {}
+            InputEvent::ImeEnabled
+            | InputEvent::ImePreedit { .. }
+            | InputEvent::ImeCommit { .. }
+            | InputEvent::KeyInput { .. }
+            | InputEvent::CharInput(_)
+            | InputEvent::ModifiersChanged(_) => {}
         }
     }
 }
@@ -826,7 +875,27 @@ impl<A: SabitoriApp> EmbeddedRunner<A> {
                 self.pointer.inside_window = false;
                 self.tree.update_hover(None);
             }
-            _ => {}
+            // `process_event` 側には最初からある腕。 こちらには無く、 `_ => {}` が
+            // 隠していた。 注入経路で cancel を受けると押下ノードが解除されず、
+            // 以後ずっと押されたままになる。 網羅マッチにした結果あらわれた実バグ。
+            InputEvent::PointerCancelled { id, .. } => {
+                self.pointer.remove(id);
+                self.pressed_node = None;
+                self.tree.set_pressed(None, false);
+            }
+
+            // --- ここから下は上の match が `return` 済み ---
+            //
+            // ワイルドカードで畳まない。 `_ => {}` だったせいで、 追加したばかりの
+            // `ModifiersChanged` が上のキーボード群にも入らずここにも落ちて、
+            // app へ一度も届かなかった (issue #12)。 網羅にしてあれば、 種別を
+            // 足した人はここで必ず判断を迫られる。
+            InputEvent::ImeEnabled
+            | InputEvent::ImePreedit { .. }
+            | InputEvent::ImeCommit { .. }
+            | InputEvent::KeyInput { .. }
+            | InputEvent::CharInput(_)
+            | InputEvent::ModifiersChanged(_) => {}
         }
         self.needs_rebuild = true;
     }

--- a/crates/sabitori/src/declarative.rs
+++ b/crates/sabitori/src/declarative.rs
@@ -10,7 +10,7 @@ use sabitori_core::build::{build_tree_measured, BuildResult};
 use sabitori_core::element::Element;
 use sabitori_core::ViewContext;
 use sabitori_gpu::{GpuContext, GpuRenderer, RingRenderer, SceneRenderContext};
-use sabitori_input::{InputEvent, Key, Modifiers, MouseButton as InputMouseButton, PointerKind, MOUSE_POINTER_ID};
+use sabitori_input::{Delivery, InputEvent, InputEventKind, Key, Modifiers, MouseButton as InputMouseButton, PointerKind, MOUSE_POINTER_ID};
 use sabitori_text::TextRenderer;
 use winit::application::ApplicationHandler;
 use winit::event::{StartCause, WindowEvent};
@@ -474,6 +474,42 @@ pub trait DeclarativeApp {
     /// `scene_3d = true`. Default no-op.
     #[cfg(not(target_arch = "wasm32"))]
     fn render_extra_scene(&mut self, _key: &str, _ctx: &mut SceneRenderContext) {}
+}
+
+/// このランタイムが [`InputEvent`] の各種別をアプリへどう届けるかの宣言。
+///
+/// [`Delivery`] の doc にある通り、 sabitori はイベント処理を共有しない 3 つの
+/// ランタイムを持つ。 この関数は [`InputEventKind`] に対する**網羅マッチ**なので、
+/// 種別が増えるとここがコンパイルエラーになり、 配線の判断を必ず通ることになる。
+///
+/// 消費側にとっては「このランタイムで何が来るか」の一覧でもある。
+/// `sabitori::scene_app::input_delivery` / `sabitori_window::input_delivery` と
+/// 見比べると、 ランタイム間の差が分かる。
+pub fn input_delivery(kind: InputEventKind) -> Delivery {
+    match kind {
+        // ポインタ系は内部の hit-test / hover / 押下追跡にも使うが、 生のイベントも
+        // そのまま `on_input` に流している。
+        InputEventKind::PointerMoved
+        | InputEventKind::PointerPressed
+        | InputEventKind::PointerReleased
+        | InputEventKind::PointerCancelled => Delivery::ToApp,
+
+        // winit の `CursorLeft` は専用コールバックに変換していて、
+        // `InputEvent::PointerLeft` は組み立てていない。
+        InputEventKind::PointerLeft => {
+            Delivery::NotProduced("カーソルの離脱は DeclarativeApp::on_cursor_left で伝える")
+        }
+
+        // IME / キーボードはフォーカス中の要素へ先に渡し、 消費されなければ
+        // `on_input` に落とす。
+        InputEventKind::ImeEnabled
+        | InputEventKind::ImePreedit
+        | InputEventKind::ImeCommit
+        | InputEventKind::KeyInput
+        | InputEventKind::CharInput => Delivery::ToApp,
+
+        InputEventKind::ModifiersChanged => Delivery::ToApp,
+    }
 }
 
 /// Per-extra-window resources. Each extra has its own GPU surface and
@@ -3142,6 +3178,9 @@ mod frame_tests {
         modifier_changes: Vec<Modifiers>,
         /// `on_input` で受けた `PointerMoved` を (kind, x, shift) で記録する。
         moves: Vec<(PointerKind, f32, bool)>,
+        /// `on_input` に届いた全イベントの種別。 `input_delivery` の宣言と
+        /// 実挙動を突き合わせるのに使う。
+        received: Vec<InputEventKind>,
     }
 
     impl DeclarativeApp for RecordingApp {
@@ -3161,6 +3200,9 @@ mod frame_tests {
         }
 
         fn on_input(&mut self, event: &InputEvent) -> bool {
+            // 種別だけを別に貯める。 `input_delivery` の宣言が実挙動と合っているかを
+            // 突き合わせるのに使う (下の declared_delivery_matches_reality)。
+            self.received.push(event.kind());
             match event {
                 InputEvent::KeyInput { key, pressed, modifiers } => {
                     self.keys.push((*key, *pressed, modifiers.shift));
@@ -3576,6 +3618,53 @@ mod frame_tests {
         assert!(state.selection.is_some());
         state.handle_key_input(Key::Other, false, Vec::new());
         assert!(state.selection.is_some());
+    }
+
+    /// `input_delivery` の宣言が、 実際にランタイムを回したときの挙動と一致すること。
+    ///
+    /// 表は手書きなので、 放っておけば実装とズレる — それでは issue #12 の
+    /// 「宣言はあるが配線が無い」 を別の形で再生産するだけになる。 ここでは
+    /// **ヘッドレスで叩ける入口を持つ種別**について、 `ToApp` と宣言したものが
+    /// 本当に `on_input` へ届くことを確認する。
+    ///
+    /// ポインタ系と IME は winit の `WindowEvent` からしか駆動できず、 それには
+    /// 窓が要るのでここでは検証できない。 ヘッドレス駆動を公開 API にする
+    /// issue #19 が入ったら、 残りもここに足すこと。
+    #[test]
+    fn declared_delivery_matches_reality() {
+        use sabitori_input::Delivery;
+
+        let mut state = AppState::new(RecordingApp::default());
+
+        // 叩ける入口: キー入力 (文字つき) と修飾キーの変化。
+        state.handle_key_input(Key::A, true, vec!['a']);
+        state.set_modifiers(Modifiers { shift: true, ..Default::default() });
+
+        let driven = [
+            InputEventKind::KeyInput,
+            InputEventKind::CharInput,
+            InputEventKind::ModifiersChanged,
+        ];
+        for kind in driven {
+            assert_eq!(
+                crate::declarative::input_delivery(kind),
+                Delivery::ToApp,
+                "{kind:?} を ToApp 以外に変えたなら、 このテストの driven からも外すこと"
+            );
+            assert!(
+                state.app.received.contains(&kind),
+                "{kind:?} は ToApp と宣言されているのに on_input へ届いていない"
+            );
+        }
+
+        // 逆向きも見る: 宣言が ToApp でない種別が紛れ込んでいないこと。
+        for kind in &state.app.received {
+            assert_eq!(
+                crate::declarative::input_delivery(*kind),
+                Delivery::ToApp,
+                "{kind:?} が on_input に届いているのに、 宣言が ToApp になっていない"
+            );
+        }
     }
 }
 

--- a/crates/sabitori/src/lib.rs
+++ b/crates/sabitori/src/lib.rs
@@ -5,8 +5,9 @@ pub use sabitori_gpu::{GpuRenderer, ImageInstance, ImageRenderer, OrbitCamera, R
 // 構築できなくなる (実際 PointerKind の欠落で下流のビルドが落ちた)。 項目を足したら
 // ここにも足すこと — tests/facade.rs がコンパイル時に見張っている。
 pub use sabitori_input::{
-    ActivePointer, InputEvent, InteractionState, Key, Modifiers, MouseButton, PointerId,
-    PointerKind, PointerState, BUTTON_MIDDLE, BUTTON_PRIMARY, BUTTON_SECONDARY, MOUSE_POINTER_ID,
+    ActivePointer, Delivery, InputEvent, InputEventKind, InteractionState, Key, Modifiers,
+    MouseButton, PointerId, PointerKind, PointerState, BUTTON_MIDDLE, BUTTON_PRIMARY,
+    BUTTON_SECONDARY, MOUSE_POINTER_ID,
 };
 pub use sabitori_layout::{LayoutEngine, LayoutNodeId, LayoutResult};
 pub use sabitori_anim::{

--- a/crates/sabitori/src/scene_app.rs
+++ b/crates/sabitori/src/scene_app.rs
@@ -12,7 +12,8 @@ use sabitori_core::build::build_tree_measured;
 use sabitori_core::ViewContext;
 use sabitori_gpu::{GpuContext, GpuRenderer, RenderPhase, SceneRenderContext};
 use sabitori_input::{
-    InputEvent, Key, Modifiers, MouseButton as SabiMouseButton, PointerKind, MOUSE_POINTER_ID,
+    Delivery, InputEvent, InputEventKind, Key, Modifiers, MouseButton as SabiMouseButton,
+    PointerKind, MOUSE_POINTER_ID,
 };
 use sabitori_text::TextRenderer;
 use winit::application::ApplicationHandler;
@@ -50,6 +51,39 @@ pub trait SceneApp: DeclarativeApp {
     /// updates while a non-primary button (middle/right) is held, so camera pan/orbit driven
     /// off `on_pointer_move` freezes mid-drag. Use this for those drags (CAD/3D-app style).
     fn on_raw_motion(&mut self, _dx: f64, _dy: f64) {}
+}
+
+/// このランタイムが [`InputEvent`] の各種別をアプリへどう届けるかの宣言。
+///
+/// [`crate::declarative::input_delivery`] と見比べること。 **同じ
+/// `DeclarativeApp` を実装していても届き方が違う種別がある。**
+/// この差は設計されたものではなく、 配線が 1 つずつ手で書かれた結果そうなった
+/// もので、 issue #22 で解消予定。 それまでは事実として宣言しておく。
+pub fn input_delivery(kind: InputEventKind) -> Delivery {
+    match kind {
+        InputEventKind::PointerMoved
+        | InputEventKind::PointerPressed
+        | InputEventKind::PointerReleased
+        | InputEventKind::PointerCancelled => Delivery::ToApp,
+
+        InputEventKind::PointerLeft => {
+            Delivery::NotProduced("カーソルの離脱は DeclarativeApp::on_cursor_left で伝える")
+        }
+
+        // ⚠️ declarative と違う: このランタイムは `Ime::Enabled` を
+        // `InputEvent` に変換していない。
+        InputEventKind::ImeEnabled => Delivery::NotProduced(
+            "未配線 — declarative では届くが SceneApp では組み立てていない (issue #22)",
+        ),
+
+        // ⚠️ declarative と違う: フォーカス中の要素が無いと**どこにも届かない**。
+        // declarative は `on_focused_input` が消費しなければ `on_input` へ落とす。
+        InputEventKind::ImePreedit | InputEventKind::ImeCommit => Delivery::FocusedOnly,
+
+        InputEventKind::KeyInput
+        | InputEventKind::CharInput
+        | InputEventKind::ModifiersChanged => Delivery::ToApp,
+    }
 }
 
 struct SceneAppState<A: SceneApp> {

--- a/crates/sabitori/tests/input_delivery.rs
+++ b/crates/sabitori/tests/input_delivery.rs
@@ -1,0 +1,126 @@
+//! 3 ランタイムの入力配信表を、 ファサード越しに突き合わせる。
+//!
+//! sabitori はイベント処理を共有しない 3 つのランタイムを持ち、 配線は 1 つずつ手で
+//! 書かれている。 その結果「core は持っているのにランタイムが配らない」 事故が
+//! 繰り返し起きた (issue #1 / #3 / #12)。 `input_delivery` は各ランタイムが全種別に
+//! ついて意思表示する網羅マッチで、 種別が増えると 3 つとも**コンパイルが壊れる**。
+//!
+//! このファイルの役目は 2 つ:
+//!
+//! 1. 表が「全種別ぶん引ける」ことの確認 (網羅マッチなので当然だが、 将来
+//!    誰かが `_` 腕を足したらここが意味を持つ)
+//! 2. **既知の乖離を固定する** — declarative と scene_app で届き方が違う種別を
+//!    明示的に assert しておき、 issue #22 で揃えたときに必ずここが落ちるようにする。
+//!    差が「いつの間にか消えた / 増えた」 のを検出する口。
+
+use sabitori::{Delivery, InputEventKind as K};
+
+/// 全種別について 3 ランタイムとも宣言を引けること。
+#[test]
+fn every_runtime_declares_every_kind() {
+    for kind in K::ALL {
+        // 引けること自体が確認事項。 網羅マッチが `_` に置き換わると、
+        // 「引けるが中身は空」 という状態になり得るのでここで舐めておく。
+        let _ = sabitori::declarative::input_delivery(*kind);
+        let _ = sabitori::scene_app::input_delivery(*kind);
+        let _ = sabitori_window::input_delivery(*kind);
+    }
+    assert_eq!(
+        K::ALL.len(),
+        11,
+        "種別を増減したら、 3 ランタイムの input_delivery と CHANGELOG を確認すること"
+    );
+}
+
+/// キーボード系はどのランタイムでもアプリに届く。 ここが崩れると、 消費側の
+/// キーバインドがランタイム依存で動かなくなる。
+#[test]
+fn keyboard_reaches_the_app_on_every_runtime() {
+    for kind in [K::KeyInput, K::CharInput, K::ModifiersChanged] {
+        assert_eq!(
+            sabitori::declarative::input_delivery(kind),
+            Delivery::ToApp,
+            "declarative: {kind:?}"
+        );
+        assert_eq!(
+            sabitori::scene_app::input_delivery(kind),
+            Delivery::ToApp,
+            "scene_app: {kind:?}"
+        );
+        assert_eq!(
+            sabitori_window::input_delivery(kind),
+            Delivery::ToApp,
+            "sabitori-window: {kind:?}"
+        );
+    }
+}
+
+/// `sabitori-window` はポインタを 1 つもアプリに渡さない。 retained な `NodeTree` が
+/// hit-test と押下追跡を持ち、 結果だけ `on_click` で伝える設計。
+#[test]
+fn sabitori_window_keeps_all_pointer_events_internal() {
+    for kind in [
+        K::PointerMoved,
+        K::PointerPressed,
+        K::PointerReleased,
+        K::PointerCancelled,
+        K::PointerLeft,
+    ] {
+        assert!(
+            matches!(sabitori_window::input_delivery(kind), Delivery::Internal(_)),
+            "{kind:?} が Internal でなくなっている。 SabitoriApp に生のポインタを\
+             渡す設計に変えたなら、 このテストと doc を更新すること"
+        );
+    }
+}
+
+/// **既知の乖離。** declarative と scene_app は同じ `DeclarativeApp` を実装させる
+/// のに、 IME の届き方が違う。 設計ではなく配線漏れなので issue #22 で揃える予定。
+/// 揃えたらこのテストは落ちる — それが正しい。
+#[test]
+fn known_ime_divergence_between_declarative_and_scene_app() {
+    // IME 有効化: declarative は届く / scene_app は組み立てていない。
+    assert_eq!(
+        sabitori::declarative::input_delivery(K::ImeEnabled),
+        Delivery::ToApp,
+    );
+    assert!(
+        matches!(
+            sabitori::scene_app::input_delivery(K::ImeEnabled),
+            Delivery::NotProduced(_)
+        ),
+        "scene_app が ImeEnabled を配るようになったなら #22 が解消済み。 \
+         このテストを消して CHANGELOG に書くこと"
+    );
+
+    // preedit / commit: declarative は on_focused_input が消費しなければ on_input へ
+    // 落とすが、 scene_app はフォーカス中の要素が無いとどこにも届かない。
+    for kind in [K::ImePreedit, K::ImeCommit] {
+        assert_eq!(
+            sabitori::declarative::input_delivery(kind),
+            Delivery::ToApp,
+            "declarative: {kind:?}"
+        );
+        assert_eq!(
+            sabitori::scene_app::input_delivery(kind),
+            Delivery::FocusedOnly,
+            "scene_app: {kind:?}"
+        );
+    }
+}
+
+/// `PointerLeft` は 2 つの winit ランタイムのどちらも組み立てない。 カーソルの離脱は
+/// `DeclarativeApp::on_cursor_left` で伝えている。 これは意図的な設計。
+#[test]
+fn pointer_left_is_reported_through_on_cursor_left() {
+    for delivery in [
+        sabitori::declarative::input_delivery(K::PointerLeft),
+        sabitori::scene_app::input_delivery(K::PointerLeft),
+    ] {
+        assert!(
+            matches!(delivery, Delivery::NotProduced(_)),
+            "PointerLeft を発行するようになったなら on_cursor_left との二重配信に\
+             なっていないか確認すること"
+        );
+    }
+}


### PR DESCRIPTION
## 何を

3 ランタイム (`DeclarativeApp` / `SceneApp` / `SabitoriApp`) はイベント処理を共有せず、配線は 1 つずつ手で書かれている。そのため「core は持っているのにランタイムが配らない」事故が繰り返し起きていた (#1 / #3 / #12)。**#12 に至っては、その修正作業の中で `sabitori-window` が新 variant を `_ => {}` で握り潰す同型のバグを作っている。**

配線漏れをレビューではなく型で止める。

- `InputEventKind` + `InputEvent::kind()` — 全 variant を知っている唯一の場所
- `Delivery` + `input_delivery()` を 3 ランタイムに追加 — `InputEventKind` に対する網羅マッチ
- `sabitori-window` のポインタ `match` から `_ => {}` を廃止

## 効くことの検証

`InputEvent` に variant を 1 つ足して、**計 6 箇所**がコンパイルエラーになることを実際に確認した:

| 箇所 | |
|---|---|
| `sabitori-input` | `InputEvent::kind()` |
| `sabitori-window` | 配信表 + `process_event` + `inject_event` |
| `sabitori` | `declarative` の配信表 + `scene_app` の配信表 |

## ついでに見つかった実バグ

`EmbeddedRunner::inject_event` に **`PointerCancelled` の腕が無かった**。`process_event` 側には最初からあるものが注入経路には無く、`_ => {}` が隠していた。ホストが cancel を注入すると押下ノードが解除されず、以後ずっと押されたままになる。網羅マッチにした結果あらわれたもので、この PR で直している。

## 配信表は仕様書でもある

書き出す過程でランタイム間の差が 2 件見つかった。設計ではなく配線漏れなので、事実として宣言に書き出したうえで #22 に切り出した。

| 種別 | declarative | scene_app |
|---|---|---|
| `ImeEnabled` | 届く | **発行しない** |
| `ImePreedit` / `ImeCommit` | `on_focused_input` → `on_input` | **フォーカス限定** |

`crates/sabitori/tests/input_delivery.rs` がこの差を assert で固定してある。#22 で揃えたら**テストが落ちる** — 差が消えたことに気づくための仕掛け。

## テスト

`cargo test --workspace` green (29 バイナリ、失敗 0)。

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)