### PR TITLE
fix(runtime): desired_focus をランタイムから括り出して Harness にも通す (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,36 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`desired_focus()` が `Harness` からは一度も適用されなかった**
+  ([#28](https://github.com/Mutafika/sabitori/issues/28))。反映の 5 行が
+  declarative ランタイムの `about_to_wait` と `scene_app` の `RedrawRequested`
+  に**手で 2 回**書かれていて、`AppState` には入っていなかった。そのため
+  `desired_focus` を実装したアプリをテストに載せると、**フォーカスは一度も動かない**。
+  実機では動くのでテストだけが落ちる。しかも `h.focused_id()` は `None` のままで
+  `unrouted_text_inputs()` にも出ない（フォーカス中の欄が無いので「行き場を失った欄」
+  ですらない）ため、**何が起きていないのかがテスト側から見えなかった**。
+
+  回避するにはテストで `h.click(<欄の id>)` を挟むしかないが、それは
+  `desired_focus` を通らない経路なので、そのテストは実機の挙動を検証していない。
+  つまり**この API を検証する手段が無かった**。
+
+  判断を `runtime_shared::apply_desired_focus` に 1 本化し、3 経路
+  （declarative / scene_app / `Harness`）が同じ実装を通るようにした。
+  [#19](https://github.com/Mutafika/sabitori/issues/19) で `advance` を括り出したのと
+  同じ穴が、その 1 行下に取り残されていた形。
+
+  適用位置も動いた。以前は「tick の直後」だったが、いまは `build_frame` の頭
+  （と `advance` の中）なので、**掴んだその同じフレームの `ctx.focused` にもう出ている**。
+  ポップアップが開いた最初の描画からフォーカス枠が光る。
+
+- **`Harness` の `capture()` がツリーの変化に追随しなかった**。`wants_pointer` は
+  「いまのマウス位置の下に UI があるか」なので、マウスが動かなくても**ツリーが変われば
+  答えが変わる**（パネルを閉じた瞬間がそれ）。ランタイムは毎 tick 押し直していたが
+  `Harness` にその経路が無く、消費側は古い答えを見ていた。上と同じ形の穴で、上を
+  直す過程で見つかった。`commit_build` の直後に押し直すようにしたので、3 経路とも揃う。
+
 ## [0.5.0] - 2026-08-14
 
 CSS にあって sabitori に無かったものを埋めた版。前半はレイアウト（grid ほか）、

--- a/crates/sabitori/src/declarative.rs
+++ b/crates/sabitori/src/declarative.rs
@@ -281,6 +281,10 @@ pub trait DeclarativeApp: 'static {
     /// open with a known input field and should keep focus until
     /// they're dismissed (Spotlight / command-palette pattern).
     /// Default `None` means "let click-to-focus drive it."
+    ///
+    /// [`testing::Harness`](crate::testing::Harness) も同じ経路を通るので、
+    /// 「クリックせずに打てる」ことをそのままテストできる — `h.frame()` を
+    /// 1 回回せば `h.focused_id()` に出る ([#28](https://github.com/Mutafika/sabitori/issues/28))。
     fn desired_focus(&self) -> Option<String> { None }
 
     /// The caret rectangle to hand the platform IME, in window-logical pixels
@@ -1719,16 +1723,9 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
         // (style spring, scroll spring, presence) and app-side async
         // drains (e.g. mpsc channel polls). Cheap enough to run every
         // frame even when we end up not redrawing.
+        // `desired_focus` の反映は `advance` / `build_frame` の中 (#28)。
+        // ここに書くと Harness からは一度も通らない。
         self.advance(dt);
-        // After tick: let the app reassert its desired focus. Popups
-        // that open with a known input (e.g. command palette) use
-        // this to grab focus the first frame they're rendered,
-        // without needing the user to click the input first.
-        if let Some(desired) = self.app.desired_focus() {
-            if self.focused_id.as_deref() != Some(&desired) {
-                self.focused_id = Some(desired);
-            }
-        }
         // Anchor the platform IME (conversion / candidate window) at the app's
         // caret. Polled every frame but deduped — only re-sent when the caret
         // rect changes — so the Cocoa call doesn't fire 125×/sec. Without this,
@@ -1931,6 +1928,11 @@ impl<A: DeclarativeApp> AppState<A> {
         h: f32,
         measurer: &dyn sabitori_core::build::TextMeasure,
     ) -> FrameBuild {
+        // アプリが主張するフォーカスを、 `view()` を呼ぶ**前**に当てる (#28)。
+        // こうしておくと、 掴んだその同じフレームの `ctx.focused` にもう出て
+        // いる — ポップアップが開いた最初の描画からフォーカス枠が光る。
+        self.apply_desired_focus();
+
         // Build scroll info for ViewContext
         let scroll_info: std::collections::HashMap<String, sabitori_core::ScrollInfo> =
             self.scroll_states
@@ -2123,6 +2125,12 @@ impl<A: DeclarativeApp> AppState<A> {
         if let Some(ref build) = self.last_build {
             self.app.on_build(build);
         }
+        // `wants_pointer` は「いまのマウス位置の下に UI があるか」なので、
+        // マウスが動かなくても**ツリーが変われば答えが変わる**。 パネルを
+        // 閉じた瞬間がそれ。 ランタイムは毎 tick 押し直していたが、
+        // Harness にはその経路が無く、 消費側は古い答えを見ていた (#28 と
+        // 同じ形の穴)。 コミット直後に押し直せば 3 経路すべてが揃う。
+        self.push_ui_capture();
     }
 
     /// `WindowEvent::KeyboardInput` の本体を winit から剥がしたもの。 `chars` は
@@ -2285,6 +2293,11 @@ impl<A: DeclarativeApp> AppState<A> {
     /// 置き去りになるのも防ぐ。
     pub(crate) fn advance(&mut self, dt: f32) {
         self.app.tick(dt);
+        // `tick` でアプリの状態が変われば、 主張するフォーカスも変わりうる。
+        // 描画されるフレームでの反映は `build_frame` 側が持つので、 ここは
+        // 「時間が進んだ結果」を拾う分 (lazy_render で描画が止まっていても
+        // フォーカスは追随する)。 どちらも同じ 1 実装を呼ぶ (#28)。
+        self.apply_desired_focus();
         // 登録済みのテキスト欄はランタイムが進める (キャレット点滅)。
         // アプリが `state.tick(dt)` を書く必要は無い。
         for (_, target) in &self.managed {
@@ -3102,6 +3115,16 @@ impl<A: DeclarativeApp> AppState<A> {
         self.hovered_id = hit.hovered_id;
         self.apply_cursor(hit.cursor);
         self.push_ui_capture();
+    }
+
+    /// [`DeclarativeApp::desired_focus`] を `focused_id` へ当てる。
+    ///
+    /// 実装は [`crate::runtime_shared::apply_desired_focus`] — scene_app と
+    /// 共有する。 掴んだら `wants_keyboard` も変わるので capture を押し直す。
+    pub(crate) fn apply_desired_focus(&mut self) {
+        if crate::runtime_shared::apply_desired_focus(&self.app, &mut self.focused_id) {
+            self.push_ui_capture();
+        }
     }
 
     /// Recompute the [`UiCapture`] snapshot and push it to the app when it

--- a/crates/sabitori/src/runtime_shared.rs
+++ b/crates/sabitori/src/runtime_shared.rs
@@ -123,6 +123,36 @@ pub(crate) fn ui_capture(
     UiCapture { wants_pointer, wants_keyboard: focused }
 }
 
+/// アプリが主張するフォーカス ([`DeclarativeApp::desired_focus`]) を
+/// `focused_id` へ当てる。 実際に変わったら `true`。
+///
+/// ポップアップが「開いた最初のフレームで中の入力欄を掴む」ための経路で、
+/// ユーザーが先にクリックしなくても打てるようにする。 `Some` を返し続ける
+/// 限り毎フレーム主張し直すので、 他所へフォーカスが移っても引き戻る。
+///
+/// ## なぜ関数に括り出すか
+///
+/// [#28](https://github.com/Mutafika/sabitori/issues/28) — この 5 行は
+/// declarative ランタイムの `about_to_wait` と `scene_app` の
+/// `RedrawRequested` に**手で 2 回**書かれていて、
+/// [`testing::Harness`](crate::testing::Harness) にはどちらも無かった。
+/// つまり `desired_focus` を使うアプリは、 **テストすると必ず
+/// 「フォーカスが入らない」ように見える**。 実機では動くのに。 #19 で
+/// `advance` を括り出したのと同じ穴が、 1 行下に残っていた形。
+pub(crate) fn apply_desired_focus<A: DeclarativeApp>(
+    app: &A,
+    focused_id: &mut Option<String>,
+) -> bool {
+    let Some(desired) = app.desired_focus() else {
+        return false;
+    };
+    if focused_id.as_deref() == Some(desired.as_str()) {
+        return false;
+    }
+    *focused_id = Some(desired);
+    true
+}
+
 /// [`ui_capture`] を算出し、 前回から変わっていればアプリへ通知する。
 pub(crate) fn push_ui_capture<A: DeclarativeApp>(
     build: Option<&BuildResult>,

--- a/crates/sabitori/src/scene_app.rs
+++ b/crates/sabitori/src/scene_app.rs
@@ -805,13 +805,10 @@ impl<A: SceneApp> ApplicationHandler for SceneAppState<A> {
                 self.app.tick(dt);
                 // After tick: let the app reassert its desired focus (e.g. a
                 // modal that opens with a known input grabs focus its first
-                // frame, without needing a click). Mirrors the declarative
-                // runtime's `about_to_wait` poll.
-                if let Some(desired) = self.app.desired_focus() {
-                    if self.focused_id.as_deref() != Some(&desired) {
-                        self.focused_id = Some(desired);
-                        self.push_ui_capture();
-                    }
+                // frame, without needing a click). 判断は declarative /
+                // Harness と同じ 1 実装を通す (#28)。
+                if crate::runtime_shared::apply_desired_focus(&self.app, &mut self.focused_id) {
+                    self.push_ui_capture();
                 }
                 // Anchor the platform IME (conversion / candidate window) at
                 // the app's caret. Polled every frame but deduped — only

--- a/crates/sabitori/tests/harness_usage.rs
+++ b/crates/sabitori/tests/harness_usage.rs
@@ -8,7 +8,7 @@
 //! の例も兼ねる。
 
 use sabitori::testing::Harness;
-use sabitori::{div, text, Element, InputEvent, Key, Modifiers, Px, ViewContext};
+use sabitori::{div, text, Element, Key, Modifiers, Px, ViewContext};
 use sabitori_widgets::{TextInputState, TextInputStyle};
 
 /// 名前を入れて保存する、それだけのアプリ。
@@ -202,4 +202,238 @@ fn paste_without_focus_does_not_touch_the_field() {
     h.paste("xyz");
 
     assert_eq!(h.app().name.text(), "");
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// `desired_focus` — クリックさせずに欄を掴む (#28)
+// ─────────────────────────────────────────────────────────────────────
+
+/// コマンドパレット。 開いている間だけ、 中の入力欄にフォーカスを主張する。
+///
+/// `desired_focus` の代表的な用途そのもの — 開いた瞬間から打てる。
+struct Palette {
+    q: TextInputState,
+    open: bool,
+}
+
+impl Palette {
+    fn new(open: bool) -> Self {
+        Self {
+            q: TextInputState::new(""),
+            open,
+        }
+    }
+}
+
+impl sabitori::DeclarativeApp for Palette {
+    fn view(&self, ctx: &ViewContext) -> Element {
+        let mut root = div().flex_col().w_full().h_full().child(
+            div()
+                .id("open")
+                .w(Px(80.0))
+                .h(Px(32.0))
+                .on_click(|| {})
+                .child(text("開く")),
+        );
+        // パレット外の focusable。 フォーカスを奪ってみる相手役。
+        root = root.child(
+            div()
+                .id("side")
+                .w(Px(80.0))
+                .h(Px(32.0))
+                .focusable()
+                .child(text("横")),
+        );
+        if self.open {
+            root = root.child(sabitori_widgets::text_input(
+                ctx,
+                "q",
+                &self.q,
+                &Form::style(),
+            ));
+        }
+        root
+    }
+
+    fn on_click(&mut self, id: &str) {
+        if id == "open" {
+            self.open = true;
+        }
+    }
+
+    fn desired_focus(&self) -> Option<String> {
+        self.open.then(|| "q".to_string())
+    }
+}
+
+/// **これが #28 の本体。** `desired_focus` を実装したアプリを Harness に載せて、
+/// クリックせずに打てること。
+///
+/// v0.5.0 までは反映が `about_to_wait` にベタ書きされていたので、 Harness からは
+/// 一度も通らなかった。 実機では動くのにテストだけが落ちる — しかも
+/// `focused_id()` が `None` のままなので、 何が起きていないのかも見えなかった。
+#[test]
+fn desired_focus_grabs_the_field_without_a_click() {
+    let mut h = Harness::new(Palette::new(true), 400.0, 400.0);
+
+    h.frame();
+
+    assert_eq!(
+        h.focused_id(),
+        Some("q"),
+        "アプリが主張したフォーカスが、 最初のフレームで入っていること"
+    );
+
+    h.text("abc");
+
+    assert_eq!(h.app().q.text(), "abc", "クリックせずに打てること");
+}
+
+/// 掴んだフレームの `view()` からもう見えていること。
+///
+/// `build_frame` の**頭**で当てているので、 掴んだその同じフレームの
+/// `ctx.focused` に出る。 フォーカス枠が 1 フレーム遅れて光らない。
+#[test]
+fn the_grabbed_focus_is_visible_to_the_same_frame() {
+    struct Probe {
+        seen: std::cell::Cell<Option<String>>,
+    }
+    impl sabitori::DeclarativeApp for Probe {
+        fn view(&self, ctx: &ViewContext) -> Element {
+            self.seen.set(ctx.focused.clone());
+            div().id("q").w(Px(80.0)).h(Px(32.0)).focusable()
+        }
+        fn desired_focus(&self) -> Option<String> {
+            Some("q".to_string())
+        }
+    }
+
+    let h_app = Probe {
+        seen: std::cell::Cell::new(None),
+    };
+    let mut h = Harness::new(h_app, 400.0, 400.0);
+    h.frame();
+
+    assert_eq!(
+        h.app().seen.take().as_deref(),
+        Some("q"),
+        "掴んだ結果は、 その掴んだフレームの ctx.focused に出ていること"
+    );
+}
+
+/// 実際の使い方 — ボタンで開いて、そのまま打つ。
+#[test]
+fn opening_the_palette_moves_focus_into_it() {
+    let mut h = Harness::new(Palette::new(false), 400.0, 400.0);
+    h.frame();
+    assert_eq!(h.focused_id(), None, "閉じている間は誰も掴まない");
+
+    h.click("open");
+    h.frame();
+
+    assert_eq!(h.focused_id(), Some("q"));
+    h.text("hi");
+    assert_eq!(h.app().q.text(), "hi");
+}
+
+/// `frame()` を呼ばず `tick()` だけでも反映されること。
+///
+/// 実機の cadence は `about_to_wait`（= tick）→ 描画なので、 lazy_render で
+/// 描画が止まっている間もフォーカスは追随する。 その経路が Harness にもある。
+#[test]
+fn desired_focus_also_applies_on_a_bare_tick() {
+    let mut h = Harness::new(Palette::new(false), 400.0, 400.0);
+    h.frame();
+
+    h.app_mut().open = true;
+    h.tick(0.016);
+
+    assert_eq!(h.focused_id(), Some("q"));
+}
+
+/// `None` の間はランタイムがフォーカスに触らないこと。
+#[test]
+fn desired_focus_of_none_leaves_focus_alone() {
+    let mut h = Harness::new(Palette::new(false), 400.0, 400.0);
+    h.frame();
+
+    h.click("side");
+    h.frame();
+
+    assert_eq!(
+        h.focused_id(),
+        Some("side"),
+        "主張が無いなら、 クリックで入ったフォーカスはそのまま"
+    );
+}
+
+/// 主張し続けている間は引き戻すこと（既存の挙動を固定する）。
+///
+/// 「モーダルが開いている間はそこから出さない」ための性質で、 `Some` を返す
+/// 限り毎フレーム主張し直す。
+#[test]
+fn desired_focus_reasserts_itself_after_focus_moves_away() {
+    let mut h = Harness::new(Palette::new(true), 400.0, 400.0);
+    h.frame();
+    assert_eq!(h.focused_id(), Some("q"));
+
+    h.click("side");
+    assert_eq!(h.focused_id(), Some("side"), "クリックの瞬間は移る");
+
+    h.frame();
+
+    assert_eq!(
+        h.focused_id(),
+        Some("q"),
+        "次のフレームでアプリが引き戻すこと"
+    );
+}
+
+/// 掴んだら `wants_keyboard` も立つこと。
+///
+/// フォーカスだけ動いて capture が古いままだと、 埋め込みホストは「UI は
+/// キーボードを要らない」と判断して打鍵を自分で食ってしまう。
+#[test]
+fn grabbing_focus_updates_the_capture_snapshot() {
+    let mut h = Harness::new(Palette::new(true), 400.0, 400.0);
+    h.frame();
+
+    assert!(
+        h.capture().wants_keyboard,
+        "掴んだ以上、 キーボードは UI が要る"
+    );
+}
+
+/// レイアウトが変わったら `capture()` も追随すること。
+///
+/// `wants_pointer` は「いまのマウス位置の下に UI があるか」なので、 マウスが
+/// 動かなくても**ツリーが変われば答えが変わる**。 実機のランタイムは毎 tick
+/// 押し直しているが、 Harness にその経路が無いと、 消費側は古い答えを見る。
+#[test]
+fn the_capture_snapshot_follows_layout_changes() {
+    struct Panel {
+        show: bool,
+    }
+    impl sabitori::DeclarativeApp for Panel {
+        fn view(&self, _ctx: &ViewContext) -> Element {
+            if self.show {
+                div().id("panel").w_full().h_full().on_click(|| {})
+            } else {
+                div()
+            }
+        }
+    }
+
+    let mut h = Harness::new(Panel { show: true }, 400.0, 400.0);
+    h.frame();
+    h.move_to(200.0, 200.0);
+    assert!(h.capture().wants_pointer, "パネルの上にいる");
+
+    h.app_mut().show = false;
+    h.frame();
+
+    assert!(
+        !h.capture().wants_pointer,
+        "パネルが消えたら、 UI はもうポインタを要らない"
+    );
 }


### PR DESCRIPTION
Closes #28

## 何が起きていたか

`desired_focus` の反映 5 行が、declarative ランタイムの `about_to_wait` と
`scene_app` の `RedrawRequested` に**手で 2 回**書かれていて、`AppState` には
入っていなかった。`testing::Harness` は `AppState` を駆動するので、
**この API は Harness から一度も通らなかった**。

つまり `desired_focus` を実装したアプリをテストに載せると、フォーカスは
一度も動かない。実機では動くので、落ちるのはテストだけ。

たちが悪いのは**何が起きていないのかが見えない**ところで、`h.focused_id()` は
`None` のままだし、`unrouted_text_inputs()` にも出ない — そもそもフォーカス中の
欄が無いので「行き場を失った欄」ですらない。回避に `h.click(<欄の id>)` を挟むと
`desired_focus` を通らない経路になるので、**そのテストは実機の挙動を検証していない**。
この API を検証する手段が事実上無かった。

#19 で `advance` を括り出したのは「ランタイムと Harness が同じ実装を通る」ため
だったが、`desired_focus` の適用は**その 1 行下**に取り残されていた。

## 直し方

判断を `runtime_shared::apply_desired_focus` に 1 本化し、3 経路
(declarative / scene_app / Harness) が同じ実装を通るようにした。
`push_ui_capture` と同じ形。

適用位置も動いている:

| | 以前 | いま |
|---|---|---|
| 場所 | `about_to_wait` の tick 直後 | `build_frame` の頭 + `advance` の中 |
| 見え方 | 掴んだ結果は**次の**フレームの `ctx.focused` | 掴んだ**その**フレームに出る |

ポップアップが開いた最初の描画からフォーカス枠が光る。`advance` からも呼ぶのは、
lazy_render で描画が止まっている間もフォーカスが追随するという既存の挙動を保つため。

## ついでに潰した同じ形の穴

`Harness` の `capture()` がツリーの変化に追随していなかった。`wants_pointer` は
「いまのマウス位置の下に UI があるか」なので、**マウスが動かなくてもツリーが変われば
答えが変わる**（パネルを閉じた瞬間がそれ）。ランタイムは毎 tick 押し直していたが
Harness にその経路が無く、消費側は古い答えを見ていた。埋め込みホストがこれを見ると
「UI はポインタを要らない」の判断を誤る。`commit_build` の直後に押し直すようにした。

上を直す過程で、同じ「ランタイムにだけある配線」を探して見つけたもの。

## テスト

`crates/sabitori/tests/harness_usage.rs` に 8 件。

- issue の再現そのもの（クリックせずに打てる）
- 掴んだ**その**フレームの `ctx.focused` に出ている
- ボタンで開いてそのまま打つ（実際の使い方）
- `tick()` だけでも反映される
- `None` の間はフォーカスに触らない ← 陰性対照
- 主張し続けている間は引き戻す（既存挙動の固定）
- 掴んだら `wants_keyboard` も立つ
- ツリーが変わったら `capture()` が追随する

**7 件は修正を外すと落ちることを確認済み**（残り 1 件は陰性対照なので両方で通る）。

## 確認

- `cargo test --workspace` → **423 passed / 0 failed**（0.5.0 時点 415 から +8）
- `cargo build --workspace --examples` → エラー無し
- 新規 warning 無し

🤖 Generated with [Claude Code](https://claude.com/claude-code)