### PR TITLE
feat(dev): view() を書き換えたまま走らせ続けられるようにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,32 @@
   いて（[#28](https://github.com/Mutafika/sabitori/issues/28)）、ヘッドレスには
   OS ウィンドウも event loop も無い。
 
+- **Rust コードのホットリロード**（`feature = "hot-reload"`、既定 off）。
+  `view()` を書き換えて保存すると、**アプリの状態を保ったまま**画面だけが更新される。
+  走行中のプロセスに機械語パッチを当てる
+  [subsecond](https://crates.io/crates/subsecond) を使い、起動は
+  `dx serve --hotpatch`（パッチを作るのは Dioxus CLI 側）。
+
+  UI 開発は「1px ずらす・色を少し変える」を何百回も回す作業で、そのたびに
+  ビルド待ち → 起動 → 目的の画面まで手で操作、を通していた。`view()` は
+  `&self` から Element を組むだけの純粋関数なので、ここを境界にすれば
+  状態を残したまま差し替えられる。
+
+  境界は `view()` / `overlay_view()` / `view_for()` の 3 箇所。状態を持つ struct の
+  フィールドを足し引きするとメモリレイアウトが変わるため、そこは `dx` が
+  フル再起動に落とす。ネイティブのみで、WASM は `trunk serve` のライブリロードを使う。
+
+  受信部（`sabitori::hot_reload`）は自前実装にした。上流の `dioxus-devtools` にも
+  同じ `connect_subsecond` があるが、VirtualDom へテンプレートを流すために
+  `dioxus-core` と `dioxus-signals` を必ず連れてくる。Sabitori に VirtualDom は無く、
+  要るのは devserver が流す jump table ひとつなので、WebSocket を直接読む 40 行に
+  置き換えた。追加依存は subsecond / tungstenite / serde_json / dioxus-cli-config の
+  4 本で、Dioxus 本体はツリーに入らない。
+
+  subsecond は `debug_assertions` が有効なときだけ働く。release ビルドでは境界が
+  素の呼び出しに畳まれるので、feature を立てたまま出荷しても実行時コストは無い。
+  devserver が居なければ黙って無効になり、`cargo run` は今までどおり動く。
+
 ## [0.6.2] - 2026-08-20
 
 テキスト欄が修飾キーを見ていなかったのを直した版。

--- a/README.ja.md
+++ b/README.ja.md
@@ -260,7 +260,36 @@ cargo run --example tui_demo      # ANSI ベースの TUI ダッシュボード
 cargo run --example tui_gallery   # アニメーションギャラリー
 cargo run --example filer         # ファイラ — ランタイム管理スクロール + 行の仮想化
 cargo run --example hello         # 低レベル API（`SabitoriApp` トレイト）
+cargo run --example hot_reload    # ホットリロードのデモ（下記）
 ```
+
+## ホットリロード（実験的）
+
+`view()` を書き換えて保存すると、**状態を保ったまま**画面だけが更新される。
+走行中のプロセスに機械語パッチを当てる [subsecond](https://crates.io/crates/subsecond)
+を使う。パッチを作るのは Dioxus CLI なので、起動が `cargo run` ではなく `dx serve`
+になる。
+
+```bash
+cargo install dioxus-cli   # 初回だけ
+dx serve --hotpatch --package sabitori --example hot_reload --features hot-reload
+```
+
+自分のアプリで有効にするのは feature ひとつで、コードの変更は要らない。
+
+```toml
+[dependencies]
+sabitori = { version = "0.6", features = ["hot-reload"] }
+```
+
+- **効く**: `view()` / `overlay_view()` / `view_for()` の中身と、そこから呼ばれる全て。
+  レイアウト・色・文言・分岐
+- **効かない**: 状態を持つ struct のフィールド追加・削除・型変更。メモリレイアウトが
+  変わるので `dx` がフル再起動に落とす
+- subsecond は `debug_assertions` が有効なときだけ働く。release では境界が素の呼び出しに
+  畳まれるので、feature を立てたまま出荷しても実行時コストは無い
+- devserver が居なければ黙って無効になる。`cargo run` は今までどおり
+- ネイティブのみ。WASM は `trunk serve` のライブリロードを使う
 
 ## アーキテクチャ
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,36 @@ cargo run --example tui_demo      # ANSI-based TUI dashboard
 cargo run --example tui_gallery   # Animation gallery
 cargo run --example filer         # File manager — runtime-managed scroll, virtualized rows
 cargo run --example hello         # Low-level API (`SabitoriApp` trait)
+cargo run --example hot_reload    # Hot-reload demo (below)
 ```
+
+## Hot Reload (experimental)
+
+Edit `view()`, hit save, and the screen updates **while the app keeps its state**.
+It uses [subsecond](https://crates.io/crates/subsecond), which patches machine code
+into the running process. The patches come from the Dioxus CLI, so you launch with
+`dx serve` rather than `cargo run`.
+
+```bash
+cargo install dioxus-cli   # once
+dx serve --hotpatch --package sabitori --example hot_reload --features hot-reload
+```
+
+Turning it on in your own app is one feature flag — no code changes.
+
+```toml
+[dependencies]
+sabitori = { version = "0.6", features = ["hot-reload"] }
+```
+
+- **Reloaded**: the bodies of `view()` / `overlay_view()` / `view_for()` and everything
+  they call — layout, colors, copy, branches
+- **Not reloaded**: adding, removing, or retyping a field on your state struct. The
+  memory layout changes, so `dx` falls back to a full restart
+- subsecond only engages when `debug_assertions` is on. In release the boundary folds
+  into a plain call, so shipping with the feature enabled costs nothing at runtime
+- With no devserver present it disables itself silently — `cargo run` is unchanged
+- Native only. On WASM, use `trunk serve` live reload
 
 ## Architecture
 

--- a/ROADMAP.ja.md
+++ b/ROADMAP.ja.md
@@ -97,5 +97,6 @@ StyleAnimator / PresenceAnimator
 
 ### その他検討中
 - ⬜ WebSocket / SSE クライアント
+- ✅ Rust コードのホットリロード（subsecond / `feature = "hot-reload"`）
 - ⬜ カスタムシェーダーホットリロード
 - ⬜ CSS Grid 専用スタイル props（現状は Taffy にパススルー）

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,5 +93,6 @@ StyleAnimator / PresenceAnimator
 
 ### Under Consideration
 - ⬜ WebSocket / SSE client
+- ✅ Rust code hot reload (subsecond / `feature = "hot-reload"`)
 - ⬜ Custom shader hot reload
 - ⬜ Dedicated CSS Grid style props (currently passed through to Taffy)

--- a/crates/sabitori/Cargo.toml
+++ b/crates/sabitori/Cargo.toml
@@ -25,6 +25,11 @@ default = ["builtin-font-jp"]
 builtin-font-jp = ["sabitori-text/builtin-font-jp"]
 builtin-font-latin = ["sabitori-text/builtin-font-latin"]
 
+# Rust コードのホットリロード (dev 専用)。`dx serve --hotpatch` と組で使う。
+# subsecond は debug_assertions が有効なときだけ働くので、有効にしたまま release を
+# 出しても実行時コストは無いが、依存を持ち込まないよう既定では off。
+hot-reload = ["dep:subsecond", "dep:dioxus-cli-config", "dep:tungstenite", "dep:serde_json"]
+
 [dependencies]
 sabitori-core.workspace = true
 sabitori-gpu.workspace = true
@@ -47,6 +52,14 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 arboard.workspace = true
 tokio = { version = "1", features = ["rt-multi-thread"] }
+# ホットリロード (feature = "hot-reload")。パッチを作るのは `dx` CLI 側で、ここに
+# あるのは走っているプロセスが受け取る口だけ。上流の dioxus-devtools を使うと
+# VirtualDom 用の dioxus-core / dioxus-signals まで付いてくるので、必要な受信処理
+# (40 行) は crates/sabitori/src/hot_reload.rs に自前で持つ。
+subsecond = { version = "0.7", optional = true }
+dioxus-cli-config = { version = "0.7", optional = true }
+tungstenite = { version = "0.28", optional = true }
+serde_json = { version = "1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen.workspace = true
@@ -152,3 +165,7 @@ path = "../../examples/landing_particles.rs"
 [[example]]
 name = "measure_headless"
 path = "../../examples/measure_headless.rs"
+
+[[example]]
+name = "hot_reload"
+path = "../../examples/hot_reload.rs"

--- a/crates/sabitori/src/declarative.rs
+++ b/crates/sabitori/src/declarative.rs
@@ -749,6 +749,19 @@ impl TextSelection {
 }
 
 impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
+    /// ホットリロードのパッチが当たったとき、`run_declarative` が張った
+    /// `EventLoopProxy` から届く。ループは待機中 `ControlFlow::Wait` で寝ている
+    /// ことがあり、自力ではコードが変わったことに気付けないので、外から起こして
+    /// 全ウィンドウを描き直させる。
+    fn user_event(&mut self, _event_loop: &ActiveEventLoop, _event: ()) {
+        if let Some(w) = &self.window {
+            w.request_redraw();
+        }
+        for extra in self.extras.values() {
+            extra.window.request_redraw();
+        }
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         if self.window.is_some() { return; }
@@ -2154,8 +2167,11 @@ impl<A: DeclarativeApp> AppState<A> {
             managed: Default::default(),
             actions: Default::default(),
         };
-        // Build main UI tree
-        let mut root = self.app.view(&ctx);
+        // Build main UI tree.
+        // `hot_reload::call` はホットリロードの境界 (feature off なら素の呼び出し)。
+        // `view` 以下で差し替わったコードは次のフレームから効き、`self` に載っている
+        // 状態はそのまま残る。
+        let mut root = crate::hot_reload::call(|| self.app.view(&ctx));
 
         // Apply presence (mount/unmount) animations
         self.presence_animator.update_presence(&root);
@@ -2202,7 +2218,7 @@ impl<A: DeclarativeApp> AppState<A> {
 
         // Build overlay tree separately (if any)
         // Merge tooltip and drag ghost into the overlay if active
-        let app_overlay = self.app.overlay_view(&ctx);
+        let app_overlay = crate::hot_reload::call(|| self.app.overlay_view(&ctx));
 
         // `view()` / `overlay_view()` の中でウィジェットが登録したものを引き取る。
         // 以後の入力配信・tick・フォーカス反映はランタイムが持つので、 アプリ側に
@@ -3465,7 +3481,7 @@ impl<A: DeclarativeApp> AppState<A> {
                 managed: Default::default(),
             actions: Default::default(),
             };
-            let root = self.app.view_for(&extra.key, &ctx);
+            let root = crate::hot_reload::call(|| self.app.view_for(&extra.key, &ctx));
             let built = build_tree_measured(&root, w, h, &measurer);
             (root, built)
         };
@@ -3547,6 +3563,14 @@ pub fn run_declarative<A: DeclarativeApp + 'static>(app: A) {
         .try_init();
 
     let event_loop = EventLoop::new().unwrap();
+
+    // ホットリロードの受け口 (feature = "hot-reload" のときだけ中身がある)。
+    // パッチは別スレッドで着弾するので、proxy 経由でループを起こして描き直す。
+    let proxy = event_loop.create_proxy();
+    crate::hot_reload::init(move || {
+        let _ = proxy.send_event(());
+    });
+
     let mut state = AppState::new(app);
     event_loop.run_app(&mut state).unwrap();
 }

--- a/crates/sabitori/src/hot_reload.rs
+++ b/crates/sabitori/src/hot_reload.rs
@@ -1,0 +1,153 @@
+//! Rust コードのホットリロード (dev 専用、`feature = "hot-reload"`)。
+//!
+//! 走っているプロセスに機械語パッチを撃ち込む [subsecond] の受け口。パッチを作る側
+//! — リンカを乗っ取り、再コンパイル前後のアセンブリ差分からシンボルを差し替える部分 —
+//! は Dioxus CLI が持っているので、起動は `cargo run` ではなく `dx serve --hotpatch`
+//! になる。CLI が入っていない / devserver が居ない場合は黙って素通りし、アプリは
+//! 通常どおり起動する。
+//!
+//! ## なぜ `dioxus-devtools` を使わないか
+//!
+//! 上流にも同じことをする [`dioxus_devtools::connect_subsecond`] があるが、あれは
+//! dioxus-core と dioxus-signals (VirtualDom へのテンプレート適用) を必ず連れてくる。
+//! Sabitori に VirtualDom は無く、欲しいのは devserver が流してくる jump table
+//! ひとつだけなので、WebSocket を自前で読む。依存は subsecond / tungstenite /
+//! serde_json / dioxus-cli-config の 4 本に収まり、Dioxus 本体は入らない。
+//!
+//! ## 何がリロードされて、何がされないか
+//!
+//! - **される**: [`DeclarativeApp::view`](crate::DeclarativeApp::view) の中身と、
+//!   そこから呼ばれる全て。レイアウト・色・文言・分岐。状態は保持される。
+//! - **されない**: アプリの状態を持つ struct のフィールド追加・削除・型変更。
+//!   メモリレイアウトが変わるため、これをやったら `dx` 側がフル再起動に落とす。
+//!
+//! subsecond は `debug_assertions` が有効なときだけ働く。release ビルドでは
+//! [`call`] は素の呼び出しに畳まれるので、feature を立てたまま出荷しても実行時
+//! コストは無い。
+//!
+//! [subsecond]: https://crates.io/crates/subsecond
+
+/// ホットリロードの境界。
+///
+/// ここより内側で呼ばれる関数はパッチ後の新しい実装に差し替わる。境界が要るのは
+/// 「今まさにスタックに載っている関数のコードが差し替わった」場合に、安全な地点まで
+/// 巻き戻す必要があるため。毎フレーム抜ける `view()` はその地点として理想的で、
+/// 逆に一度きりしか通らない初期化を包んでも意味がない。
+///
+/// feature が off、または WASM ターゲットでは `f()` をそのまま呼ぶだけ。
+#[inline]
+pub fn call<O>(f: impl FnMut() -> O) -> O {
+    imp::call(f)
+}
+
+/// devserver への接続を開き、パッチが当たるたびに `on_patch` を呼ぶ。
+///
+/// `on_patch` は WebSocket を読んでいる別スレッドから呼ばれる。ここで直接描画は
+/// できないので、イベントループを叩き起こして再描画を要求する用途に使う
+/// (`run_declarative` は `EventLoopProxy` を送る)。
+///
+/// devserver が居なければ何もしない。ホットリロードなしで普通に動く。
+#[inline]
+pub fn init(on_patch: impl Fn() + Send + Sync + 'static) {
+    imp::init(on_patch);
+}
+
+#[cfg(all(feature = "hot-reload", not(target_arch = "wasm32")))]
+mod imp {
+    use std::sync::Arc;
+
+    pub fn call<O>(f: impl FnMut() -> O) -> O {
+        subsecond::call(f)
+    }
+
+    pub fn init(on_patch: impl Fn() + Send + Sync + 'static) {
+        subsecond::register_handler(Arc::new(on_patch));
+
+        let Some(endpoint) = dioxus_cli_config::devserver_ws_endpoint() else {
+            tracing::info!(
+                "hot-reload: devserver が見つからないので無効。\
+                 有効にするには `dx serve --hotpatch` で起動する"
+            );
+            return;
+        };
+
+        // aslr_reference は「このプロセスの main がどこに載ったか」。ASLR で毎回
+        // ずれるので、パッチ側がシンボルを解決するには実行中プロセスから教える
+        // しかない。接続 URL に載せるのが devserver プロトコルの作法。
+        let uri = format!(
+            "{endpoint}?aslr_reference={}&build_id={}&pid={}",
+            subsecond::aslr_reference(),
+            dioxus_cli_config::build_id(),
+            std::process::id(),
+        );
+
+        let spawned = std::thread::Builder::new()
+            .name("sabitori-hot-reload".into())
+            .spawn(move || {
+                let mut ws = match tungstenite::connect(&uri) {
+                    Ok((ws, _)) => ws,
+                    Err(e) => {
+                        tracing::warn!("hot-reload: devserver に接続できない: {e}");
+                        return;
+                    }
+                };
+                tracing::info!("hot-reload: devserver に接続した");
+                while let Ok(msg) = ws.read() {
+                    if let tungstenite::Message::Text(text) = msg {
+                        apply(&text);
+                    }
+                }
+                tracing::info!("hot-reload: devserver との接続が切れた");
+            });
+        if let Err(e) = spawned {
+            tracing::warn!("hot-reload: 受信スレッドを起動できない: {e}");
+        }
+    }
+
+    /// devserver のメッセージから jump table だけ取り出して適用する。
+    fn apply(text: &str) {
+        let Ok(msg) = serde_json::from_str::<serde_json::Value>(text) else {
+            return;
+        };
+        // 外部タグ付き enum: `{"HotReload": {..}}`。他の variant (FullReloadCommand,
+        // Shutdown など) は VirtualDom を持つアプリ向けなので黙って捨てる。Value 経由
+        // で読むのは、上流が variant やフィールドを足しても壊れないようにするため。
+        let Some(hot) = msg.get("HotReload") else {
+            return;
+        };
+        // 一つの devserver に複数プロセスがぶら下がることがある。自分宛て以外を
+        // 当てると他プロセス向けのコードを踏むので、pid 一致は必須。
+        if hot.get("for_pid").and_then(serde_json::Value::as_u64) != Some(u64::from(std::process::id())) {
+            return;
+        }
+        // テンプレートだけ変わった (Rust コードは無傷の) 通知には jump table が無い。
+        let Some(table) = hot.get("jump_table").filter(|t| !t.is_null()) else {
+            return;
+        };
+        let table: subsecond::JumpTable = match serde_json::from_value(table.clone()) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!("hot-reload: jump table を読めない: {e}");
+                return;
+            }
+        };
+
+        // SAFETY: table は dx が「今このプロセスで走っているバイナリ」向けに吐き、
+        // pid 一致で自分宛てだと確認済みのもの。適用に成功すると subsecond が
+        // `init` で登録したハンドラを呼び、再描画が要求される。
+        if let Err(e) = unsafe { subsecond::apply_patch(table) } {
+            tracing::warn!("hot-reload: パッチ適用に失敗: {e}");
+        }
+    }
+}
+
+#[cfg(not(all(feature = "hot-reload", not(target_arch = "wasm32"))))]
+mod imp {
+    #[inline(always)]
+    pub fn call<O>(mut f: impl FnMut() -> O) -> O {
+        f()
+    }
+
+    #[inline(always)]
+    pub fn init(_on_patch: impl Fn() + Send + Sync + 'static) {}
+}

--- a/crates/sabitori/src/lib.rs
+++ b/crates/sabitori/src/lib.rs
@@ -37,6 +37,7 @@ pub mod scroll_sync;
 mod runtime_shared;
 pub mod slider_sync;
 pub mod image_runtime;
+pub mod hot_reload;
 pub(crate) mod input_router;
 pub mod scene_app;
 /// システムクリップボードの読み書き (issue #20)。

--- a/crates/sabitori/tests/hot_reload.rs
+++ b/crates/sabitori/tests/hot_reload.rs
@@ -1,0 +1,43 @@
+//! `hot_reload` シムの契約。
+//!
+//! ホットパッチそのもの (dx が撃つ jump table の適用) はここでは検証できない。
+//! 検証するのは、feature を on/off どちらにしても **アプリの振る舞いが変わらない**
+//! こと — つまりホットリロードを切った本番ビルドが、有効なときと同じ結果を返す
+//! こと。ここが崩れると「開発中は動くのに release で挙動が違う」という最悪の
+//! バグクラスが生まれる。
+
+use sabitori::hot_reload;
+
+#[test]
+fn call_returns_the_closure_value() {
+    assert_eq!(hot_reload::call(|| 40 + 2), 42);
+}
+
+#[test]
+fn call_is_transparent_to_captured_state() {
+    // `view` は `&self` を借りて Element を組む。シムがその借用を邪魔しないこと。
+    let label = String::from("sabitori");
+    let out = hot_reload::call(|| format!("{label}!"));
+    assert_eq!(out, "sabitori!");
+}
+
+#[test]
+fn call_runs_the_closure_exactly_once() {
+    // `FnMut` を取るので、うっかり複数回呼ぶ実装だと `view` の副作用が二重になる。
+    let mut calls = 0;
+    hot_reload::call(|| calls += 1);
+    assert_eq!(calls, 1);
+}
+
+#[test]
+fn call_nests() {
+    // overlay は view の内側で組まれることがある。境界の入れ子で死なないこと。
+    assert_eq!(hot_reload::call(|| hot_reload::call(|| 7) + 1), 8);
+}
+
+#[test]
+fn init_without_a_devserver_is_a_noop() {
+    // `cargo run` で普通に起動した場合。devserver は居ないので、接続を諦めて
+    // 静かに帰るだけで、パニックもブロックもしてはいけない。
+    hot_reload::init(|| unreachable!("パッチが来ていないのにハンドラが呼ばれた"));
+}

--- a/examples/hot_reload.rs
+++ b/examples/hot_reload.rs
@@ -1,0 +1,74 @@
+//! ホットリロードのデモ。
+//!
+//! ```sh
+//! cargo install dioxus-cli          # 初回だけ
+//! dx serve --hotpatch --package sabitori --example hot_reload --features hot-reload
+//! ```
+//!
+//! 起動したらボタンを何回か押してカウンタを上げ、そのまま下の `view` の中身
+//! (色・文言・サイズ・レイアウト) を書き換えて保存する。**カウンタの値を保ったまま**
+//! 画面だけが変われば成功。
+//!
+//! 逆に `HotReloadDemo` のフィールドを足し引きすると状態のメモリレイアウトが
+//! 変わるので、そこは dx がフル再起動に落とす (＝カウンタは 0 に戻る)。
+//! これは制約であって不具合ではない。
+
+use sabitori::element::*;
+use sabitori::*;
+
+/// ここを触るとフル再起動。`view` の中だけならホットリロードで済む。
+struct HotReloadDemo {
+    clicks: u32,
+}
+
+// ── ここから下を書き換えて保存すると、走ったまま画面が変わる ──────────────
+
+const BG: &str = "#1a1b26";
+const FG: &str = "#c0caf5";
+const ACCENT: &str = "#7aa2f7";
+const HEADLINE: &str = "Edit me while I'm running";
+
+impl DeclarativeApp for HotReloadDemo {
+    fn title(&self) -> &str {
+        "Sabitori — hot reload"
+    }
+
+    fn size(&self) -> (f32, f32) {
+        (720.0, 480.0)
+    }
+
+    fn view(&self, ctx: &ViewContext) -> Element {
+        div()
+            .w(Px(ctx.width))
+            .h(Px(ctx.height))
+            .bg(Color::from_hex(BG))
+            .flex_col()
+            .items_center()
+            .justify_center()
+            .gap(20.0)
+            .children([
+                text(HEADLINE)
+                    .font_size(28.0)
+                    .color(Color::from_hex(FG)),
+                text(&format!("clicks: {}", self.clicks))
+                    .font_size(48.0)
+                    .color(Color::from_hex(ACCENT)),
+                button("Click me").id("bump").accent(Color::from_hex(ACCENT)),
+                text("この値を残したまま、上の const や view を書き換えて保存")
+                    .font_size(14.0)
+                    .color(Color::from_hex(FG).with_alpha(0.5)),
+            ])
+    }
+
+    fn on_click(&mut self, id: &str) {
+        if id == "bump" {
+            self.clicks += 1;
+        }
+    }
+}
+
+// ── ここまで ────────────────────────────────────────────────────────
+
+fn main() {
+    sabitori::run_declarative(HotReloadDemo { clicks: 0 });
+}


### PR DESCRIPTION
## 何をしたか

`view()` を書き換えて保存すると、**アプリの状態を保ったまま**画面だけが更新されるようにした。走行中のプロセスに機械語パッチを当てる [subsecond](https://crates.io/crates/subsecond) を使う。

```bash
cargo install dioxus-cli   # 初回だけ
dx serve --hotpatch --package sabitori --example hot_reload --features hot-reload
```

`examples/hot_reload.rs` はそれを目で確認するためのデモ。ボタンでカウンタを上げてから `view` の中の色や文言を書き換えると、**カウンタの値が残ったまま**画面だけが変わる。

## なぜ

UI の実装は「1px ずらす・色を少し変える」を何百回も回す作業なのに、そのたびにビルドを待ち、起動し、目的の画面まで手で操作し直していた。1 サイクルの長さがそのまま開発速度になっている。

`DeclarativeApp::view` は `&self` から Element を組むだけの純粋関数で、状態は App 側の struct に載っている。**view だけを差し替えれば状態を残したまま画面を作り直せる形に、最初からなっていた。**

## 設計

境界は毎フレーム抜ける `view()` / `overlay_view()` / `view_for()` の 3 箇所。パッチは別スレッドで着弾するので、`EventLoopProxy` でループを起こして描き直す（待機中は `ControlFlow::Wait` で寝ていて自力では気付けない）。

**受信部は自前に書いた。** 上流の `dioxus-devtools` にも同じ `connect_subsecond` があるが、VirtualDom へテンプレートを流すために `dioxus-core` と `dioxus-signals` を必ず連れてくる。Sabitori に VirtualDom は無く、要るのは devserver が流す jump table ひとつなので、WebSocket を直接読む 40 行（`crates/sabitori/src/hot_reload.rs`）に置き換えた。追加依存は subsecond / tungstenite / serde_json / dioxus-cli-config の 4 本で、**Dioxus 本体はツリーに入らない**。

## 安全側

- `feature = "hot-reload"` は既定 off
- devserver が居なければ黙って無効になり、`cargo run` は今までどおり動く
- subsecond は `debug_assertions` が有効なときだけ働くので、feature を立てたまま release を出しても実行時コストは無い
- ネイティブのみ。WASM は `trunk serve` のライブリロードを使う

## 制約

状態を持つ struct のフィールドを足し引きするとメモリレイアウトが変わるので、そこは `dx` がフル再起動に落とす。**制約であって不具合ではない**（README / CHANGELOG に明記）。

## 検証

| | 結果 |
|---|---|
| `cargo check -p sabitori`（feature off / on） | ✅ |
| `cargo test --workspace` | ✅ 38 スイート全パス、回帰なし |
| `cargo test -p sabitori --test hot_reload`（off / on） | ✅ 5 件 |
| `cargo test -p sabitori --test readme_examples` | ✅ 12 件（追加した節は bash / toml ブロックのみ） |
| `dx serve` での実動作 | ⚠️ **未検証** — 手元に dioxus-cli が無い |

テストは feature の on/off で振る舞いが変わらないことを見ている。ここが崩れると「開発中は動くのに release で挙動が違う」というバグクラスが生まれるため。

最後の行だけ残っている。プロトコルは上流の `connect_subsecond` と同じ実装に揃えてあるが、実際にパッチが着弾して画面が変わるところまでは確認できていない。**マージ前に一度 `dx serve` を通したい。**

## 別件（この PR では触っていない）

`cargo deny --all-features check licenses` が **main の時点で既に落ちている**。`arboard` → `clipboard-win` / `error-code` が BSL-1.0（Boost、permissive）で、`deny.toml` の allow に入っていないため。AGPL/GPL を弾くという方針とは矛盾しないので allow に 1 行足すだけだが、この PR の範囲外なので別で出す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
