### PR TITLE
ci(license): ライセンス周りが黙って壊れるのを止める

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,53 @@
+# ライセンス周りが黙って壊れるのを止める。
+#
+# 実際に起きたこと: v0.4.0 で arboard が入り、その依存の BSL-1.0 が deny.toml の
+# allow に無かったため `cargo deny check licenses` が赤くなった。誰も回していな
+# かったので v0.7.0 まで 4 マイナー分気付かれず、同じ期間 THIRD-PARTY-LICENSES.html
+# も再生成されないまま、arboard (MIT/Apache-2.0) の帰属が抜けた状態で放置された。
+#
+# どちらも「依存を足した PR がその場で赤くなる」ようにすれば起きない。
+name: license
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  # 依存を触っていなくても、新しい RUSTSEC 勧告や cargo-deny の更新で
+  # 状況は変わる。週 1 で気付けるようにしておく。
+  schedule:
+    - cron: "0 0 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  licenses:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # deny と about は起動のたびにビルドすると数分かかる。バイナリを取る。
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny,cargo-about
+
+      # allow リストに無いライセンスが混ざっていないこと。
+      # `--all-features` は hot-reload の依存 (subsecond / tungstenite ほか) も
+      # 検査対象に入れるため — 既定 off でも、有効にした利用者には効いてくる。
+      - name: cargo deny check licenses
+        run: cargo deny --all-features check licenses
+
+      # 配布物の帰属表示が現在の依存と一致していること。
+      # 生成は決定的なので、差分が出た = 依存が変わったのに再生成していない。
+      - name: THIRD-PARTY-LICENSES.html が最新か
+        run: |
+          cargo about generate about.hbs -o /tmp/third-party.html --all-features
+          if ! diff -q THIRD-PARTY-LICENSES.html /tmp/third-party.html > /dev/null; then
+            echo "::error::THIRD-PARTY-LICENSES.html が依存ツリーとずれています。"
+            echo "::error::次を実行してコミットしてください:"
+            echo "::error::  cargo about generate about.hbs -o THIRD-PARTY-LICENSES.html --all-features"
+            diff -u THIRD-PARTY-LICENSES.html /tmp/third-party.html | head -60
+            exit 1
+          fi


### PR DESCRIPTION
## なぜ

このリポジトリには **CI が無く**、`cargo deny` も `cargo about` も誰も回していなかった。結果として 2 つが同時に、**4 マイナー分放置された**。

| | 起きたこと |
|---|---|
| `cargo deny check licenses` | v0.4.0 で `arboard` が入り、その依存の BSL-1.0 が `deny.toml` の allow に無くて赤くなった。v0.7.0 まで誰も気付かなかった |
| `THIRD-PARTY-LICENSES.html` | 同じ期間再生成されず、`arboard` / `clipboard-win` / `error-code` / `subsecond` / `tungstenite` の 5 本が抜けた |

2 番目は**実害のある漏れ**だった。MIT と Apache-2.0 は配布物に著作権表示を含めることを要求していて、その義務を実際に果たしているのがこのファイルだから（`arboard` は MIT/Apache-2.0）。どちらも既に main で修正済みだが、**同じことがまた起きる構造は残っている**。

「依存を足した PR がその場で赤くなる」ならこれは起きない。

## 検査 2 つ

**1. `cargo deny --all-features check licenses`**

allow に無いライセンスが混ざっていないこと。`--all-features` なのは `hot-reload` の依存（subsecond / tungstenite ほか）も見るため。既定 off でも、有効にした利用者には効いてくる。

**2. `THIRD-PARTY-LICENSES.html` を再生成して diff**

生成は決定的なので、**差分が出た = 依存が変わったのに再生成していない**。落ちたときは実行すべきコマンドをログに出す。

```
::error::THIRD-PARTY-LICENSES.html が依存ツリーとずれています。
::error::次を実行してコミットしてください:
::error::  cargo about generate about.hbs -o THIRD-PARTY-LICENSES.html --all-features
```

## ゲートが実際に落ちることを確認した

通ることだけ確かめても検査として機能している証明にならないので、手元で落としてみた。

| | 結果 |
|---|---|
| 現状 | PASS |
| ツリーに無いクレート（`strsim`）を足して再生成を忘れる | **FAIL** ✅ |
| 戻す | PASS |

最初 `itoa` で試したときは PASS のままだった。調べると `itoa` は `http` ← `tungstenite` 経由で**既にツリーにいた**ためで、ゲートの不具合ではなくテストが無効だった。既にいるクレートを直接依存に格上げしても帰属の内容は変わらないので、PASS が正しい挙動。

## 実行タイミング

`push` (main) / `pull_request` に加えて **週 1（月曜 0:00 UTC）**。依存を触っていなくても、新しい RUSTSEC 勧告やツールの更新で状況は変わるため。

`cargo-deny` / `cargo-about` は毎回ビルドすると数分かかるので `taiki-e/install-action` でバイナリを取る。

## スコープ

**ライセンスに限定した。** `cargo test --workspace`（38 スイート）も現状誰も自動で回していないが、それは別の話なので混ぜていない。

同じ理由で、`cargo deny check` の残り 2 つ（`advisories` / `bans`）もこの workflow には入れていない。どちらも今 落ちていて、判断が要る:

- **advisories**: RUSTSEC-2026-0194（`wayland-scanner` ← winit、Linux のみ）/ RUSTSEC-2026-0204（`crossbeam-deque` ← rayon ← cosmic-text）。上流を上げるか、影響を評価して ignore するかの判断が要る
- **bans**: inter-crate 依存に `version = "..."` が無い（`wildcards = "deny"` に抵触）。**ROADMAP の既知項目**で、crates.io 公開とセットで潰すのが自然

赤いまま CI に入れると、今回と同じ「誰も読まないゲート」を作ることになるので外した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
