### PR TITLE
fix(gpu)!: 画像だけ・文字だけの overlay が描かれない (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,32 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **画像だけ・文字だけの overlay が描かれなかった**
+  ([#44](https://github.com/Mutafika/sabitori/issues/44))。
+
+  `render_layered` の overlay パスが、その層の**矩形の数**で守られていた。
+  だが矩形はレンダラ自身が描き、画像・リング・線・文字は callback 越しに描かれる。
+  つまり「矩形が 0」と「描く物が無い」は別の問いで、前者で後者を代用していた。
+
+  地を塗っていない `div` は矩形を出さないので、`drag_ghost` に画像を 1 枚置いた
+  だけの層が**丸ごと落ちた**。しかも入力も hit region も callback も全部正しく
+  動くので、「絵だけが出ない」という掴みにくい壊れ方をする。ツールチップと
+  コンテキストメニューが無事だったのは、たまたま両方とも地を塗っていたから。
+
+  `overlay_has_content` を受け取り、矩形が 0 でも中身があれば層を開く。
+  この判定はレンダラ側では出せない — 描くのは opaque な `draw_fn` なので、
+  呼び出し側が言うしかない。
+
+  同じ形が `render_scene_then_ui_layered` にもあった（報告には無かった 2 箇所目）。
+
+### Changed
+
+- **破壊的**: `GpuRenderer::render_layered` と
+  `GpuRenderer::render_scene_then_ui_layered` に `overlay_has_content: bool` が
+  増えた。`UiDrawLists::is_empty()` を否定して渡せばよい。
+
 ## [0.7.0] - 2026-08-21
 
 書き換えたまま走らせ続けられるようにした版。

--- a/crates/sabitori-core/src/build.rs
+++ b/crates/sabitori-core/src/build.rs
@@ -3300,3 +3300,81 @@ mod z_index_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod overlay_content_tests {
+    //! **地を塗っていない層は矩形を 1 つも出さない。**
+    //!
+    //! これ自体は正しい (塗る物が無いので描く矩形も無い)。問題は、レンダラが
+    //! 「この層に描く物があるか」を矩形の数で判定していたこと。画像だけ /
+    //! 文字だけの overlay が丸ごと落ち、しかも入力も callback も正しく動くので
+    //! 「絵だけが出ない」という掴みにくい壊れ方をした
+    //! ([#44](https://github.com/Mutafika/sabitori/issues/44))。
+    //!
+    //! ここで固定するのはその前提 — 矩形の数は中身の有無の代わりにならない。
+
+    use super::*;
+    use crate::element::{div, image, text, ImageData, Px};
+
+    fn counts(root: &Element) -> (usize, usize, usize) {
+        let built = build_tree(root, 800.0, 600.0);
+        let mut rects = 0;
+        let mut images = 0;
+        let mut texts = 0;
+        for cmd in &built.render_list.commands {
+            match cmd {
+                RenderCommand::Rect(_) => rects += 1,
+                RenderCommand::Image(_) => images += 1,
+                RenderCommand::Text(_) => texts += 1,
+                _ => {}
+            }
+        }
+        (rects, images, texts)
+    }
+
+    fn a_pixel() -> ImageData {
+        ImageData::new(vec![255, 0, 0, 255], 1, 1)
+    }
+
+    /// ドラッグゴーストが消えていた形そのもの。
+    #[test]
+    fn an_image_only_layer_emits_no_rect() {
+        let root = div()
+            .w(Px(96.0))
+            .h(Px(96.0))
+            .children([image("ghost", a_pixel()).w(Px(96.0)).h(Px(96.0))]);
+        let (rects, images, _) = counts(&root);
+        assert_eq!(rects, 0, "地を塗っていない div は矩形を出さない");
+        assert_eq!(images, 1, "しかし描く物はある");
+    }
+
+    /// 文字だけの overlay も同じ。
+    #[test]
+    fn a_text_only_layer_emits_no_rect() {
+        let root = div().w(Px(200.0)).h(Px(40.0)).children([text("運搬中")]);
+        let (rects, _, texts) = counts(&root);
+        assert_eq!(rects, 0);
+        assert_eq!(texts, 1);
+    }
+
+    /// **ツールチップとコンテキストメニューが無事だった理由。**
+    /// たまたま両方とも地を塗っていたので、矩形が出て層が開いた。
+    #[test]
+    fn a_background_is_what_produced_a_rect() {
+        let root = div()
+            .w(Px(96.0))
+            .h(Px(96.0))
+            .bg(crate::Color::new(0.1, 0.1, 0.1, 1.0))
+            .children([image("ghost", a_pixel()).w(Px(96.0)).h(Px(96.0))]);
+        let (rects, images, _) = counts(&root);
+        assert_eq!(rects, 1, "地を塗ると矩形が出る — これが回避策になっていた");
+        assert_eq!(images, 1);
+    }
+
+    /// 本当に何も無い層は、矩形も中身も 0。
+    #[test]
+    fn an_empty_layer_has_neither() {
+        let (rects, images, texts) = counts(&div().w(Px(10.0)).h(Px(10.0)));
+        assert_eq!((rects, images, texts), (0, 0, 0));
+    }
+}

--- a/crates/sabitori-gpu/src/renderer.rs
+++ b/crates/sabitori-gpu/src/renderer.rs
@@ -701,10 +701,21 @@ impl GpuRenderer {
     /// The `draw_fn` closure is called twice with different [`RenderPhase`]
     /// values, so the caller can use a single `&mut TextRenderer` without
     /// borrow-checker issues.
+    /// `overlay_has_content` says whether the overlay layer draws anything
+    /// *other than* rects — images, rings, lines, glyphs. It cannot be derived
+    /// here: those are drawn by `draw_fn`, which is opaque to the renderer.
+    ///
+    /// Gating the overlay pass on `overlay_rects` alone loses whole layers.
+    /// An undecorated `div` emits no rect, so an overlay holding only an image
+    /// (a drag ghost) or only text never opened its pass and vanished — with
+    /// every other signal, hit regions and callbacks included, still correct.
+    /// Tooltips and context menus survived only because both happen to set a
+    /// background ([#44](https://github.com/Mutafika/sabitori/issues/44)).
     pub fn render_layered(
         &mut self,
         base_rects: &[RectInstance],
         overlay_rects: &[RectInstance],
+        overlay_has_content: bool,
         mut draw_fn: impl FnMut(RenderPhase, &mut wgpu::RenderPass<'_>, &wgpu::BindGroup),
     ) -> Result<(), wgpu::SurfaceError> {
         let base_count = base_rects.len();
@@ -776,7 +787,7 @@ impl GpuRenderer {
         }
 
         // Pass 2: overlay layer — separate encoder + submit
-        if overlay_count > 0 {
+        if overlay_count > 0 || overlay_has_content {
             let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
                 label: Some("sabitori_overlay_encoder"),
             });
@@ -961,11 +972,16 @@ impl GpuRenderer {
     /// paint over an overlay's background. Base and overlay rects share one
     /// instance buffer (overlay appended after base), matching
     /// [`Self::render_layered`].
+    /// `overlay_has_content` carries the same meaning as in
+    /// [`render_layered`](Self::render_layered): whether the overlay layer
+    /// draws anything other than rects. Same trap, same reason it cannot be
+    /// derived here.
     pub fn render_scene_then_ui_layered(
         &mut self,
         scene_fn: impl FnOnce(&mut SceneRenderContext),
         base_rects: &[RectInstance],
         overlay_rects: &[RectInstance],
+        overlay_has_content: bool,
         mut draw_fn: impl FnMut(RenderPhase, &mut wgpu::RenderPass<'_>, &wgpu::BindGroup),
     ) -> Result<(), wgpu::SurfaceError> {
         let base_count = base_rects.len();
@@ -1057,7 +1073,7 @@ impl GpuRenderer {
         }
 
         // === Pass 3: overlay UI (no depth, LoadOp::Load) ===
-        if overlay_count > 0 {
+        if overlay_count > 0 || overlay_has_content {
             let mut encoder = self.device.create_command_encoder(
                 &wgpu::CommandEncoderDescriptor {
                     label: Some("sabitori_scene_ui_overlay_encoder"),

--- a/crates/sabitori/src/bridge.rs
+++ b/crates/sabitori/src/bridge.rs
@@ -697,6 +697,7 @@ pub fn extract_image_batches(list: &RenderList) -> Vec<ImageBatch> {
 ///
 /// Built once per render list so the draw site does not have to remember which
 /// extraction call yields which kind — see [`draw_ui_layer`].
+#[derive(Default)]
 pub struct UiDrawLists {
     pub images: Vec<ImageBatch>,
     pub rings: Vec<RingInstance>,
@@ -705,6 +706,20 @@ pub struct UiDrawLists {
 }
 
 impl UiDrawLists {
+    /// Whether this layer has nothing to draw.
+    ///
+    /// The renderer takes rects itself and hands everything else back through
+    /// a phase callback, so "no rects" and "nothing to draw" are different
+    /// questions. A layer holding only an image, or only text, has zero rects
+    /// (an undecorated `div` emits none) but is very much not empty — see
+    /// [`GpuRenderer::render_layered`](sabitori_gpu::GpuRenderer::render_layered).
+    pub fn is_empty(&self) -> bool {
+        self.images.is_empty()
+            && self.rings.is_empty()
+            && self.lines.is_empty()
+            && self.glyphs.is_empty()
+    }
+
     /// Extract every non-rect draw kind from one render list, returning the
     /// rects alongside (they are drawn by the renderer itself, before the pass
     /// callback runs).
@@ -1125,5 +1140,64 @@ mod fullpath_verify {
         let out = std::env::temp_dir().join("polyline_fullpath.png");
         image::save_buffer(&out, &data[..], w, h, image::ExtendedColorType::Rgba8).unwrap();
         eprintln!("WROTE {}", out.display());
+    }
+}
+
+#[cfg(test)]
+mod overlay_emptiness_tests {
+    //! `UiDrawLists::is_empty` は、レンダラに「この層を開くべきか」を伝えるための
+    //! 判定。矩形はレンダラ自身が描き、それ以外は callback 越しなので、
+    //! 「矩形が 0」と「描く物が無い」は別の問いになる ([#44]).
+    //!
+    //! [#44]: https://github.com/Mutafika/sabitori/issues/44
+
+    use super::*;
+
+    fn a_pixel() -> sabitori_core::ImageData {
+        sabitori_core::ImageData::new(vec![255, 0, 0, 255], 1, 1)
+    }
+
+    #[test]
+    fn nothing_at_all_is_empty() {
+        assert!(UiDrawLists::default().is_empty());
+    }
+
+    /// ドラッグゴーストの形 — 画像だけ。矩形は 0 でも、層は空ではない。
+    #[test]
+    fn an_image_alone_is_not_empty() {
+        let lists = UiDrawLists {
+            images: vec![ImageBatch {
+                key: "ghost".into(),
+                data: a_pixel(),
+                instances: Vec::new(),
+            }],
+            ..Default::default()
+        };
+        assert!(!lists.is_empty());
+    }
+
+    /// 文字だけの層も同じ。
+    #[test]
+    fn glyphs_alone_are_not_empty() {
+        let lists = UiDrawLists {
+            glyphs: vec![bytemuck::Zeroable::zeroed()],
+            ..Default::default()
+        };
+        assert!(!lists.is_empty());
+    }
+
+    /// リング / 線だけの層も落としてはいけない。
+    #[test]
+    fn rings_and_lines_alone_are_not_empty() {
+        let rings = UiDrawLists {
+            rings: vec![bytemuck::Zeroable::zeroed()],
+            ..Default::default()
+        };
+        let lines = UiDrawLists {
+            lines: vec![bytemuck::Zeroable::zeroed()],
+            ..Default::default()
+        };
+        assert!(!rings.is_empty(), "リングだけの層");
+        assert!(!lines.is_empty(), "線だけの層");
     }
 }

--- a/crates/sabitori/src/declarative.rs
+++ b/crates/sabitori/src/declarative.rs
@@ -1589,6 +1589,10 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
                     let _ = renderer.render_layered(
                         &base_rects,
                         &overlay_rects,
+                        // 矩形の数だけでは overlay の有無を判定できない。地を塗って
+                        // いない div は矩形を出さないので、画像だけ / 文字だけの
+                        // overlay が丸ごと落ちる (#44)。
+                        !overlay_lists.is_empty(),
                         |phase, pass, globals_bg| {
                             let lists = match phase {
                                 RenderPhase::BaseText => &base_lists,

--- a/crates/sabitori/src/scene_app.rs
+++ b/crates/sabitori/src/scene_app.rs
@@ -1030,6 +1030,8 @@ impl<A: SceneApp> ApplicationHandler for SceneAppState<A> {
                         },
                         &base_rects,
                         &overlay_rects,
+                        // 矩形の数だけでは overlay の有無を判定できない (#44)。
+                        !overlay_lists.is_empty(),
                         |phase, pass, globals_bg| {
                             let lists = match phase {
                                 RenderPhase::BaseText => &base_lists,


### PR DESCRIPTION
Closes #44

## 原因

`render_layered` の overlay パスが、その層の**矩形の数**で守られていた。

```rust
if overlay_count > 0 {          // overlay_count = overlay_rects.len()
    ...
    draw_fn(RenderPhase::OverlayText, &mut pass, ..);   // 画像・リング・線・文字は全部この中
}
```

矩形はレンダラ自身が描き、それ以外は callback 越しに描かれる。つまり**「矩形が 0」と「描く物が無い」は別の問い**で、前者で後者を代用していた。

地を塗っていない `div` は矩形を出さないので、`drag_ghost` に画像を 1 枚置いただけの層が丸ごと落ちる。報告どおり、**入力も hit region も callback も全部正しく動くのに絵だけが出ない**という掴みにくい壊れ方をする。ツールチップとコンテキストメニューが無事だったのは、たまたま両方とも地を塗っていたから。

## 報告に無かった 2 箇所目

同じ形が `render_scene_then_ui_layered` の Pass 3 にもあった。`SceneApp` 側の overlay も同じ条件で落ちる。そちらも直した。

```
renderer.rs:779   if overlay_count > 0 {    ← 報告された箇所
renderer.rs:1060  if overlay_count > 0 {    ← もう 1 つ
```

## 直し方（提案 A）

`overlay_has_content: bool` を受け取り、矩形が 0 でも中身があれば層を開く。

**この判定はレンダラ側では出せない。** 描くのは opaque な `draw_fn` なので、呼び出し側が言うしかない。呼び出し側は `UiDrawLists` を持っているので `is_empty()` を足して否定を渡す。

提案 B（overlay があれば常に 2 枚目を開く）は採らなかった。呼び出し側が `render_layered` を**常に**呼んでいるため、overlay の無いアプリが毎フレーム空の render pass + submit を 1 つ余計に払うことになる。

提案 C（doc に「矩形が要る」と書く）は不要になった。もう要らないので。

## テスト 8 本

GPU を持ち出さずに済む形で、**罠の前提そのもの**を固定した。

`sabitori-core` 側 — `build_tree` の出力:

| | Rect | Image / Text |
|---|---|---|
| `div().children([image(..)])` | **0** | 1 |
| `div().children([text(..)])` | **0** | 1 |
| `div().bg(..).children([image(..)])` | 1 | 1 |

3 行目が、ツールチップとコンテキストメニューが無事だった理由をそのまま示している。

`sabitori` 側 — `UiDrawLists::is_empty()` が画像 / 文字 / リング / 線のどれか 1 つでも入っていれば `false` を返すこと。

`cargo test --workspace` → 38 スイート全パス。

## 破壊的変更

`GpuRenderer::render_layered` と `GpuRenderer::render_scene_then_ui_layered` に `overlay_has_content: bool` が増えた。`!UiDrawLists::is_empty()` を渡せばよい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
