### PR TITLE
fix(testing): Harness からドラッグを最後まで運べるようにする (#48, #49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,40 @@
 
 ### Fixed
 
+- **Harness からドラッグを最後まで運べなかった**
+  ([#48](https://github.com/Mutafika/sabitori/issues/48))。
+
+  `Harness::move_to` はホバーの更新しかしておらず、`DragManager` を前に進めて
+  いなかった。`DragManager` は 5px の閾値を `on_move` の中で見て `Pending` →
+  `Active` に上げるので、**Harness からはドラッグが永遠に成立しない**。
+  `press_at` → `move_to` → `release` と書いても「押しっぱなしで動かしただけ」で、
+  `ctx.drag` は `None` のまま、`on_drop` も `drag_ghost` も呼ばれなかった。
+
+  **[#44](https://github.com/Mutafika/sabitori/issues/44) がテストの外に居座って
+  いたのはこれが理由。** `drag_ghost` を書いてもテストから踏めないので、固定できた
+  のは「掴める物として組まれているか」と「`on_drop` が正しく動かすか」の両端だけ
+  だった。真ん中は実機で目視するしかなく、そこで落ちていた。
+
+  実機の `CursorMoved` の中身を `pointer_moved_to` として括り出し、ランタイムと
+  Harness が同じ 1 本を通るようにした。片方にしか無い処理を作れなくするため —
+  `tick` を `advance` に括り出したのと同じ理由
+  ([#28](https://github.com/Mutafika/sabitori/issues/28))。
+
+### Added
+
+- **`Harness::hovered_id`** — いまポインタの下にある要素の id
+  ([#49](https://github.com/Mutafika/sabitori/issues/49))。`focused_id` と対称。
+
+  「ホバーしても光らない」は**塗りが弱い**のか**追跡が死んでいる**のかに分かれる。
+  これはその 2 つを分けるための口。アプリが `view()` の中で `ctx.hovered` を控えに
+  書き写して読む手もあるが、それでは確かめているのがランタイムの状態ではなく
+  アプリの控えになる。
+
+- **`Harness::drag_info` / `Harness::dragging`** — 運搬中の状態を外から読む。
+  上のドラッグ経路をテストで検査するために必要。
+
+### Fixed
+
 - **画像テクスチャが一度も解放されず、GPU メモリが単調に増えていた**
   ([#43](https://github.com/Mutafika/sabitori/issues/43))。
 

--- a/crates/sabitori/src/declarative.rs
+++ b/crates/sabitori/src/declarative.rs
@@ -635,7 +635,8 @@ pub(crate) struct AppState<A: DeclarativeApp> {
     pub(crate) last_build: Option<BuildResult>,
     pub(crate) mouse_x: f32,
     pub(crate) mouse_y: f32,
-    hovered_id: Option<String>,
+    /// `focused_id` と同じく Harness から読めるようにしてある (#49)。
+    pub(crate) hovered_id: Option<String>,
     /// 現在押されている要素の id。`active_style` (= `.active()` / `.pressable()`)
     /// を畳むのに使う。押下で入り、解放・キャンセル・ウィンドウ外への離脱で消える。
     /// hover と同じく「id を 1 つ持つ」だけの単純な状態で、押したまま外へ払っても
@@ -681,7 +682,8 @@ pub(crate) struct AppState<A: DeclarativeApp> {
     /// Managed tooltip hover-delay state.
     tooltip_state: sabitori_widgets::TooltipState,
     /// Managed drag & drop state.
-    drag_manager: sabitori_widgets::DragManager,
+    /// Harness からも状態を読めるようにしてある (#48)。
+    pub(crate) drag_manager: sabitori_widgets::DragManager,
     /// Animated style transitions (hover spring animations).
     style_animator: sabitori_widgets::StyleAnimator,
     /// Presence (mount/unmount) animator.
@@ -905,45 +907,13 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
                 if self.primary_input == PrimaryInput::Touch {
                     return;
                 }
-                if let Some(r) = self.renderer.as_ref() {
-                    let s = r.scale_factor;
-                    self.mouse_x = position.x as f32 / s;
-                    self.mouse_y = position.y as f32 / s;
-                }
-                self.update_hover();
-                self.app.on_pointer_move(self.mouse_x, self.mouse_y);
-                // マウスの移動も `PointerMoved` として配る。 `InputEvent::PointerMoved`
-                // の doc は "For mouse, fires for both hover and drag" と言っているのに、
-                // このランタイムは touch 分しか出していなかった (`SabitoriApp` は出す)。
-                // `on_pointer_move` は座標しか渡さないので、 修飾キーを見るには
-                // こちらが要る — ⇧ドラッグの直交スナップのような「押している間だけ」の
-                // 操作は、 動いている最中の状態が取れないと書けない。
-                self.app.on_input(&InputEvent::PointerMoved {
-                    id: MOUSE_POINTER_ID,
-                    kind: PointerKind::Mouse,
-                    position: sabitori_core::Point::new(self.mouse_x, self.mouse_y),
-                    modifiers: self.modifiers,
-                });
-                self.drag_manager.on_move(self.mouse_x, self.mouse_y);
-                // text selection drag: button held + selecting=true なら head を更新。
-                // hit_test_text が None でも head は前の値を保持 (= 端の text 上で
-                // 止まる、 巻き戻りで戻れる)。
-                if self.selecting {
-                    // drag 中は最近傍 snap (strict=false)。 anchor は既に実テキスト上に
-                    // 立っているので、 段落の外へ払っても選択が伸び続けてよい。
-                    if let Some(head) = self.hit_test_text(self.mouse_x, self.mouse_y, false) {
-                        let snap = self
-                            .text_layouts
-                            .iter()
-                            .find(|l| l.text_idx == head.0)
-                            .map(|l| l.content.clone())
-                            .unwrap_or_default();
-                        if let Some(ref mut sel) = self.selection {
-                            sel.head = head;
-                            sel.head_content = snap;
-                        }
-                    }
-                }
+                // 論理座標に直す。renderer が無い間は前の値のまま
+                // (`pointer_moved_to` への代入が no-op になる)。
+                let (x, y) = match self.renderer.as_ref() {
+                    Some(r) => (position.x as f32 / r.scale_factor, position.y as f32 / r.scale_factor),
+                    None => (self.mouse_x, self.mouse_y),
+                };
+                self.pointer_moved_to(x, y);
             }
             WindowEvent::CursorEntered { .. } => {
                 // The pointer enters carrying whatever OS cursor the previous
@@ -2014,6 +1984,60 @@ impl<A: DeclarativeApp> AppState<A> {
                     extra.window.request_redraw();
                 }
                 None => self.spawn_extra(event_loop, spec),
+            }
+        }
+    }
+
+    /// ポインタが論理座標 `(x, y)` へ動いたときにランタイムがすること。
+    ///
+    /// 実機の `CursorMoved` と [`Harness::move_to`](crate::testing::Harness::move_to)
+    /// の両方がここを通る。**片方にしか無い処理を作らないため**に括り出してある。
+    ///
+    /// 実際そうなっていた: Harness 側は `update_hover` しか呼んでおらず、
+    /// `drag_manager.on_move` が無かった。`DragManager` は 5px の閾値をそこで見て
+    /// `Pending` → `Active` に上げるので、Harness からはドラッグが永遠に成立せず、
+    /// `on_drop` も `drag_ghost` も踏めなかった。おかげで「画像だけの overlay が
+    /// 描かれない」がテストの外に居座り、実機で目視するまで見つからなかった
+    /// ([#48](https://github.com/Mutafika/sabitori/issues/48),
+    /// [#44](https://github.com/Mutafika/sabitori/issues/44))。
+    ///
+    /// `tick` を `advance` に括り出したのと同じ理由
+    /// ([#28](https://github.com/Mutafika/sabitori/issues/28))。
+    pub(crate) fn pointer_moved_to(&mut self, x: f32, y: f32) {
+        self.mouse_x = x;
+        self.mouse_y = y;
+        self.update_hover();
+        self.app.on_pointer_move(self.mouse_x, self.mouse_y);
+        // マウスの移動も `PointerMoved` として配る。 `InputEvent::PointerMoved`
+        // の doc は "For mouse, fires for both hover and drag" と言っているのに、
+        // このランタイムは touch 分しか出していなかった (`SabitoriApp` は出す)。
+        // `on_pointer_move` は座標しか渡さないので、 修飾キーを見るには
+        // こちらが要る — ⇧ドラッグの直交スナップのような「押している間だけ」の
+        // 操作は、 動いている最中の状態が取れないと書けない。
+        self.app.on_input(&InputEvent::PointerMoved {
+            id: MOUSE_POINTER_ID,
+            kind: PointerKind::Mouse,
+            position: sabitori_core::Point::new(self.mouse_x, self.mouse_y),
+            modifiers: self.modifiers,
+        });
+        self.drag_manager.on_move(self.mouse_x, self.mouse_y);
+        // text selection drag: button held + selecting=true なら head を更新。
+        // hit_test_text が None でも head は前の値を保持 (= 端の text 上で
+        // 止まる、 巻き戻りで戻れる)。
+        if self.selecting {
+            // drag 中は最近傍 snap (strict=false)。 anchor は既に実テキスト上に
+            // 立っているので、 段落の外へ払っても選択が伸び続けてよい。
+            if let Some(head) = self.hit_test_text(self.mouse_x, self.mouse_y, false) {
+                let snap = self
+                    .text_layouts
+                    .iter()
+                    .find(|l| l.text_idx == head.0)
+                    .map(|l| l.content.clone())
+                    .unwrap_or_default();
+                if let Some(ref mut sel) = self.selection {
+                    sel.head = head;
+                    sel.head_content = snap;
+                }
             }
         }
     }

--- a/crates/sabitori/src/testing.rs
+++ b/crates/sabitori/src/testing.rs
@@ -270,11 +270,50 @@ impl<A: DeclarativeApp> Harness<A> {
         self.state.focused_id.as_deref()
     }
 
-    /// 座標を指定してポインタを動かす。 ホバーの更新まで行う。
+    /// いまポインタの下にある要素の id。
+    ///
+    /// `focused_id` と同じ立場で、`UiCapture` からは引けないので直に出す。
+    /// アプリ側からは `ViewContext::hovered` で同じ値が見える。
+    ///
+    /// 「ホバーしても光らない」は 2 つに分かれる — **塗りが弱い**のか、
+    /// **追跡が死んでいる**のか。これはその 2 つを分けるための口
+    /// ([#49](https://github.com/Mutafika/sabitori/issues/49))。
+    /// アプリが `view()` の中で `ctx.hovered` を控えに書き写して読む手もあるが、
+    /// それでは確かめているのがランタイムの状態ではなくアプリの控えになる。
+    pub fn hovered_id(&self) -> Option<&str> {
+        self.state.hovered_id.as_deref()
+    }
+
+    /// いま運んでいる物 — `(payload, 掴んだ要素の id)`。運んでいなければ `None`。
+    ///
+    /// `press_at` だけでは `None` のまま。`DragManager` は 5px の閾値を越えて
+    /// 初めて `Pending` から `Active` に上がるので、`move_to` で動かす必要がある
+    /// ([#48](https://github.com/Mutafika/sabitori/issues/48))。
+    ///
+    /// アプリ側から見た `ViewContext::drag` と違い、こちらは `over_drop_zone` を
+    /// 含まない — あれはフレームを組むときに hit_regions から引かれるので、
+    /// `frame()` を回した後の `ViewContext` で見ること。
+    pub fn drag_info(&self) -> Option<(String, Option<String>)> {
+        self.state.drag_manager.drag_info()
+    }
+
+    /// いま何かを運んでいるか。
+    pub fn dragging(&self) -> bool {
+        self.state.drag_manager.is_active()
+    }
+
+    /// 座標を指定してポインタを動かす。
+    ///
+    /// 実機の `CursorMoved` と同じ 1 本 (`pointer_moved_to`) を通るので、
+    /// ホバーの更新だけでなく `on_pointer_move` / `on_input(PointerMoved)` /
+    /// ドラッグの前進 / テキスト選択の伸長まで、実機と同じことが起きる。
+    ///
+    /// かつてはホバーの更新しかしておらず、`DragManager` を前に進めていなかった。
+    /// 5px の閾値を越えられないので、Harness からはドラッグが永遠に成立せず、
+    /// `press_at` → `move_to` → `release` と書いても「押しっぱなしで動かしただけ」
+    /// になっていた ([#48](https://github.com/Mutafika/sabitori/issues/48))。
     pub fn move_to(&mut self, x: f32, y: f32) {
-        self.state.mouse_x = x;
-        self.state.mouse_y = y;
-        self.state.update_hover();
+        self.state.pointer_moved_to(x, y);
     }
 
     /// 座標を指定して主ボタンを押して離す。
@@ -541,5 +580,126 @@ mod tests {
         let mut h = Harness::new(Counter::default(), 400.0, 300.0);
         h.frame();
         h.click("nope");
+    }
+}
+
+#[cfg(test)]
+mod drag_and_hover_tests {
+    //! Harness からドラッグを最後まで運べること ([#48]) と、ホバー追跡を
+    //! 外から読めること ([#49])。
+    //!
+    //! **[#44] がテストの外に居座っていた区間がここ。** `move_to` が
+    //! `DragManager` を前に進めていなかったので、`drag_ghost` を書いても
+    //! テストから踏む手段が無く、実機で目視するまで壊れていることに気付けなかった。
+    //!
+    //! [#48]: https://github.com/Mutafika/sabitori/issues/48
+    //! [#49]: https://github.com/Mutafika/sabitori/issues/49
+    //! [#44]: https://github.com/Mutafika/sabitori/issues/44
+
+    use super::*;
+    use crate::ViewContext;
+    use sabitori_core::element::*;
+
+    #[derive(Default)]
+    struct DragApp {
+        /// `on_drop` が届いた記録: (運んだ物, 落とした先)。
+        dropped: Vec<(String, String)>,
+    }
+
+    impl DeclarativeApp for DragApp {
+        fn view(&self, _ctx: &ViewContext) -> Element {
+            div().w(Px(400.0)).h(Px(200.0)).flex_row().children([
+                div()
+                    .id("card")
+                    .w(Px(100.0))
+                    .h(Px(100.0))
+                    .bg(sabitori_core::Color::new(0.2, 0.4, 0.9, 1.0))
+                    .draggable("card-1"),
+                div()
+                    .id("bin")
+                    .w(Px(100.0))
+                    .h(Px(100.0))
+                    .bg(sabitori_core::Color::new(0.9, 0.2, 0.2, 1.0))
+                    .droppable(),
+            ])
+        }
+
+        fn drag_ghost(&self, _ctx: &ViewContext) -> Option<Element> {
+            Some(div().w(Px(20.0)).h(Px(20.0)))
+        }
+
+        fn on_drop(&mut self, data: &str, target_id: &str) {
+            self.dropped.push((data.into(), target_id.into()));
+        }
+    }
+
+    fn harness() -> Harness<DragApp> {
+        let mut h = Harness::new(DragApp::default(), 400.0, 200.0);
+        h.frame();
+        h
+    }
+
+    /// **報告された形そのもの。** press → move → release で `on_drop` が届く。
+    #[test]
+    fn a_drag_can_be_carried_all_the_way_to_a_drop() {
+        let mut h = harness();
+        h.press_at(50.0, 50.0);
+        h.move_to(150.0, 50.0); // 閾値 5px を大きく越える
+        h.frame();
+        h.release();
+
+        assert_eq!(
+            h.app().dropped,
+            vec![("card-1".to_string(), "bin".to_string())],
+            "on_drop が届いていない"
+        );
+    }
+
+    /// ドラッグ中はランタイムが運搬状態を持っている。
+    #[test]
+    fn the_drag_is_visible_while_carrying() {
+        let mut h = harness();
+        h.press_at(50.0, 50.0);
+        h.move_to(150.0, 50.0);
+        assert!(h.dragging(), "運んでいる最中なのに drag が立っていない");
+        assert_eq!(
+            h.drag_info().map(|(d, _)| d),
+            Some("card-1".to_string()),
+            "運んでいる物が取れない"
+        );
+    }
+
+    /// **5px を越えないと始まらない。** 閾値の扱いは実機と同じ。
+    #[test]
+    fn a_press_without_movement_is_not_a_drag() {
+        let mut h = harness();
+        h.press_at(50.0, 50.0);
+        h.move_to(52.0, 50.0); // 2px — 閾値未満
+        assert!(!h.dragging(), "2px で drag が始まってしまった");
+        h.release();
+        assert!(h.app().dropped.is_empty(), "drop していないのに on_drop が来た");
+    }
+
+    /// drop zone の外で離したら、何も落ちない。
+    #[test]
+    fn releasing_outside_a_drop_zone_drops_nothing() {
+        let mut h = harness();
+        h.press_at(50.0, 50.0);
+        h.move_to(50.0, 180.0); // どちらの箱でもない所
+        h.frame();
+        h.release();
+        assert!(h.app().dropped.is_empty());
+    }
+
+    /// #49: ホバー追跡を外から読める。
+    #[test]
+    fn the_hovered_id_is_readable() {
+        let mut h = harness();
+        h.move_to(50.0, 50.0);
+        assert_eq!(h.hovered_id(), Some("card"));
+        h.move_to(150.0, 50.0);
+        assert_eq!(h.hovered_id(), Some("bin"));
+        h.move_to(50.0, 190.0);
+        assert_eq!(h.hovered_id(), None, "どの要素の上でもない");
     }
 }


### PR DESCRIPTION
Closes #48, closes #49

## #48 — 真ん中の 1 本が無かった

報告どおり、切れているのは 1 箇所でした。`Harness::move_to` はホバーの更新しかしておらず、`DragManager` を前に進めていない。閾値 5px は `on_move` の中で見ているので、**Harness からはドラッグが永遠に `Pending` のまま**になります。

両端（`start_pending` / `on_release`）は既に動いていました。

### #44 が生き残った理由がこれです

`drag_ghost` を書いてもテストから踏む手段が無いので、固定できたのは「掴める物として組まれているか」と「`on_drop` が正しく動かすか」の**両端だけ**。真ん中は実機で目視するしかなく、そこで落ちていました。

## 1 行足すのではなく括り出しました

提案は `move_to` に `drag_manager.on_move` を 1 行足す形でしたが、実機の `CursorMoved` は**5 つ**のことをしています。

```
update_hover
on_pointer_move
on_input(PointerMoved)
drag_manager.on_move          ← 今回足りなかったのはこれ
テキスト選択の伸長
```

今回足りなかったのは 1 つですが、**片方にしか無い処理はまた増えます**。実機の中身を `pointer_moved_to` として括り出し、ランタイムと Harness が同じ 1 本を通るようにしました。`tick` を `advance` に括り出したのと同じ理由（#28）です。

副作用として、Harness の `move_to` は `on_pointer_move` / `on_input(PointerMoved)` / テキスト選択の伸長も実機どおり起こすようになります。既存 38 スイートに回帰はありません。

## #49 — `hovered_id()`

`focused_id` と対称に出しました。報告の「アプリが控えに書き写して読むのでは、確かめているのがランタイムの状態ではない」はそのとおりだと思います。

検査に必要なので `drag_info()` / `dragging()` も足しました。これが無いと #48 の経路をテストから観測できません。

## テストが実際に落ちることを確認

通るだけでは何も証明していないので、`move_to` を元の実装に戻して確かめました。

| テスト | 旧実装 | 新実装 |
|---|---|---|
| `a_drag_can_be_carried_all_the_way_to_a_drop` | **FAILED** | ok |
| `the_drag_is_visible_while_carrying` | **FAILED** | ok |
| `a_press_without_movement_is_not_a_drag` | ok | ok |
| `releasing_outside_a_drop_zone_drops_nothing` | ok | ok |
| `the_hovered_id_is_readable` | ok | ok |

閾値未満（2px）でドラッグが始まらないことも固定しました。ここが緩むと、クリックが全部ドラッグになります。

`cargo test --workspace` → 38 スイート全パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
