### PR TITLE
feat(gpu): テクスチャの使用量を見えるようにし、入れ替えの口を足す (#47, #50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,34 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`ViewContext::textures`** — 画像テクスチャの GPU 使用状況をアプリから見える
+  ようにした ([#47](https://github.com/Mutafika/sabitori/issues/47))。
+  `bytes` / `count` / `budget_bytes` / `evictions_total` / `evicted_last_frame`。
+
+  長時間起動でだんだん様子がおかしくなる、という話を調べるとき、アプリ側からは
+  自分がどれだけ抱えているかが全く見えなかった。窓の外から `ps -o rss` を
+  サンプリングして症状の時刻と突き合わせる、という推測の域を出ない調べ方に
+  なっていた。数字が 1 つ窓の中に出せれば「見れば分かる」に変わる。
+
+  **`evicted_last_frame` が 0 でないまま続くなら、予算が 1 フレームぶんの
+  working set より小さい。** 毎フレーム捨てては入れ直しているので、絵は正しく
+  出たまま静かに遅くなる。追い出しは「今フレーム使われた鍵は捨てない」「収まらない
+  時は超過を許す」と安全側に倒れているぶん、超過が常態化していることは外に出さないと
+  分からない。
+
+- **`ImageRenderer::replace_texture`** — 同じ鍵のままテクスチャの中身を入れ替える
+  ([#50](https://github.com/Mutafika/sabitori/issues/50))。
+
+  `ensure_texture` は既存の鍵で早期 return するので、「同じ物を指す鍵だが中身は
+  変わった」を表す手段が鍵を変えることしかなかった。ファイルを指す画像なら鍵に
+  更新時刻を混ぜることになり、作り直すたびに別テクスチャが増える。
+  `drop_texture` → `ensure_texture` の 2 段でも同じだが、前半を書き忘れると
+  **古い絵が出続ける** — 壊れずに間違う形になる。
+
+- **`ImageRenderer::texture_stats`** — 上の統計を低レベル側から取る口。
+
 ### Fixed
 
 - **画像テクスチャが一度も解放されず、GPU メモリが単調に増えていた**

--- a/crates/sabitori-core/src/lib.rs
+++ b/crates/sabitori-core/src/lib.rs
@@ -69,6 +69,31 @@ pub struct TooltipInfo {
 // DragInfo — active drag state
 // ---------------------------------------------------------------------------
 
+/// 画像テクスチャの GPU 側の使用状況。
+///
+/// 長時間起動でだんだん様子がおかしくなる、という話を調べるとき、アプリ側からは
+/// 自分がどれだけ抱えているかが全く見えなかった。窓の外から `ps -o rss` を
+/// サンプリングして症状の時刻と突き合わせる、という推測の域を出ない調べ方に
+/// なっていた ([#47](https://github.com/Mutafika/sabitori/issues/47))。
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TextureStats {
+    /// いまテクスチャが占めている bytes。
+    pub bytes: usize,
+    /// いま持っているテクスチャの枚数。
+    pub count: usize,
+    /// 上限 (`DeclarativeApp::texture_budget_bytes`)。
+    pub budget_bytes: usize,
+    /// 起動からの累計追い出し数。
+    pub evictions_total: u64,
+    /// 直近の 1 フレームで追い出した数。
+    ///
+    /// **0 でないまま続くなら、予算が 1 フレームぶんの working set より小さい。**
+    /// 毎フレーム捨てては入れ直しているので、絵は正しく出たまま静かに遅くなる。
+    /// 追い出しは「今フレーム使われた鍵は捨てない」「収まらない時は超過を許す」と
+    /// 安全側に倒れているぶん、超過が常態化していることは外に出さないと分からない。
+    pub evicted_last_frame: usize,
+}
+
 /// Information about an active drag operation.
 #[derive(Clone, Debug)]
 pub struct DragInfo {
@@ -161,6 +186,9 @@ pub struct ViewContext<'a> {
     pub tooltip: Option<TooltipInfo>,
     /// Active drag operation info (if any).
     pub drag: Option<DragInfo>,
+    /// 画像テクスチャの使用状況。計測器を持たないホスト (testing harness 等) では
+    /// 全部 0 になる。
+    pub textures: TextureStats,
     /// Framework-level theme with semantic color names.
     pub theme: AppTheme,
     /// Presence animation progress values: id -> progress (0.0-1.0).
@@ -604,6 +632,7 @@ mod view_context_tests {
             scroll_states: std::collections::HashMap::new(),
             tooltip: None,
             drag: None,
+            textures: Default::default(),
             theme: AppTheme::default(),
             presence: std::collections::HashMap::new(),
             images: None,

--- a/crates/sabitori-gpu/src/image_renderer.rs
+++ b/crates/sabitori-gpu/src/image_renderer.rs
@@ -252,6 +252,45 @@ impl ImageRenderer {
     // テクスチャ寿命の制御 (#43)
     // ---------------------------------------------------------------
 
+    /// 同じ鍵のまま、テクスチャの中身を入れ替える。
+    ///
+    /// [`ensure_texture`](Self::ensure_texture) は既存の鍵で早期 return するので、
+    /// 「同じ物を指す鍵だが中身は変わった」を表す手段が鍵を変えることしか
+    /// なかった。ファイルを指す画像なら鍵に更新時刻やハッシュを混ぜることになり、
+    /// **作り直すたびに別テクスチャが増える**
+    /// ([#50](https://github.com/Mutafika/sabitori/issues/50))。
+    ///
+    /// `drop_texture` してから `ensure_texture` する 2 段でも同じことはできるが、
+    /// 前半を書き忘れると**古い絵が出続ける** — 壊れずに間違う形になる。
+    /// 入れ替えたいならこちらを 1 回呼ぶ。
+    pub fn replace_texture(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        key: &str,
+        rgba: &[u8],
+        width: u32,
+        height: u32,
+    ) {
+        self.drop_texture(key);
+        self.ensure_texture(device, queue, key, rgba, width, height);
+    }
+
+    /// 画像テクスチャの GPU 側の使用状況。
+    ///
+    /// 長時間起動でだんだん様子がおかしくなる、という調べ物のための数字
+    /// ([#47](https://github.com/Mutafika/sabitori/issues/47))。宣言的アプリからは
+    /// `ViewContext::textures` で同じ物が見える。
+    pub fn texture_stats(&self) -> sabitori_core::TextureStats {
+        sabitori_core::TextureStats {
+            bytes: self.budget.used_bytes(),
+            count: self.textures.len(),
+            budget_bytes: self.budget.budget_bytes(),
+            evictions_total: self.budget.evictions_total(),
+            evicted_last_frame: self.budget.evicted_last_frame(),
+        }
+    }
+
     /// このフレームの描画が終わったことをキャッシュに伝える。
     ///
     /// **フレームにつき 1 回、全パスを描き終えてから**呼ぶこと。パスごとに

--- a/crates/sabitori-gpu/src/texture_budget.rs
+++ b/crates/sabitori-gpu/src/texture_budget.rs
@@ -34,6 +34,16 @@ pub struct TextureBudget {
     used_bytes: usize,
     generation: u64,
     entries: HashMap<String, Entry>,
+    /// 起動からの累計追い出し数。
+    ///
+    /// 予算が実際の working set より小さいと「毎フレーム捨てて入れ直す」が起きる。
+    /// **絵は正しく出続けるので壊れて見えず、静かに遅くなるだけ**なので、
+    /// 外から見える数字が無いと原因が予算だと気付けない
+    /// ([#47](https://github.com/Mutafika/sabitori/issues/47))。
+    evictions_total: u64,
+    /// 直近の 1 フレームで追い出した数。0 でないまま続くなら予算が足りない。
+    evicted_last_frame: usize,
+    evicted_this_frame: usize,
 }
 
 impl TextureBudget {
@@ -49,6 +59,9 @@ impl TextureBudget {
             used_bytes: 0,
             generation: 0,
             entries: HashMap::new(),
+            evictions_total: 0,
+            evicted_last_frame: 0,
+            evicted_this_frame: 0,
         }
     }
 
@@ -93,6 +106,22 @@ impl TextureBudget {
     /// **今から描く物を追い出してしまう**。
     pub fn end_frame(&mut self) {
         self.generation = self.generation.wrapping_add(1);
+        self.evicted_last_frame = self.evicted_this_frame;
+        self.evicted_this_frame = 0;
+    }
+
+    /// 起動からの累計追い出し数。
+    pub fn evictions_total(&self) -> u64 {
+        self.evictions_total
+    }
+
+    /// 直近の 1 フレームで追い出した数。
+    ///
+    /// **これが 0 でないまま続くなら、予算が 1 フレームぶんの working set より
+    /// 小さい。** 毎フレーム捨てては入れ直しているので、絵は正しく出たまま
+    /// 静かに遅くなる。`set_texture_budget_bytes` を上げるか、描く画像を減らす。
+    pub fn evicted_last_frame(&self) -> usize {
+        self.evicted_last_frame
     }
 
     /// `bytes` の新しいテクスチャを入れる前に、**追い出すべき鍵**を返す。
@@ -117,6 +146,8 @@ impl TextureBudget {
             let e = self.entries.remove(&victim).expect("lru_victim は entries から選ぶ");
             self.used_bytes -= e.bytes;
             evicted.push(victim);
+            self.evictions_total = self.evictions_total.wrapping_add(1);
+            self.evicted_this_frame += 1;
         }
 
         self.entries.insert(
@@ -330,6 +361,62 @@ mod tests {
         b.set_budget_bytes(2 * full());
         b.admit("d", full());
         assert!(b.used_bytes() <= 2 * full(), "{} bytes", b.used_bytes());
+    }
+
+    /// **追い出しが起きたことが外から見える。**
+    ///
+    /// 予算が working set より小さいと毎フレーム捨てて入れ直すが、絵は正しく
+    /// 出続けるので壊れて見えない。数字が出ないと原因が予算だと気付けない (#47)。
+    #[test]
+    fn evictions_are_counted() {
+        let mut b = TextureBudget::new(2 * full());
+        assert_eq!(b.evictions_total(), 0);
+        assert_eq!(b.evicted_last_frame(), 0);
+
+        b.admit("a", full());
+        b.admit("b", full());
+        b.end_frame();
+        assert_eq!(b.evictions_total(), 0, "予算内なら追い出していない");
+
+        b.admit("c", full()); // a か b が 1 枚出る
+        assert_eq!(b.evictions_total(), 1);
+        // end_frame を跨ぐまでは前フレームの数字のまま
+        assert_eq!(b.evicted_last_frame(), 0);
+        b.end_frame();
+        assert_eq!(b.evicted_last_frame(), 1);
+    }
+
+    /// **予算が足りない状態は `evicted_last_frame` が 0 に戻らないことで分かる。**
+    #[test]
+    fn a_too_small_budget_keeps_evicting_every_frame() {
+        let mut b = TextureBudget::new(2 * full());
+        // 毎フレーム 3 枚の別画像を描く = working set が予算を超えている
+        for f in 0..10 {
+            for i in 0..3 {
+                b.admit(&format!("img-{i}"), full());
+            }
+            b.end_frame();
+            if f > 0 {
+                assert!(
+                    b.evicted_last_frame() > 0,
+                    "予算が足りないのに追い出しが 0 と報告された"
+                );
+            }
+        }
+        assert!(b.evictions_total() >= 10);
+    }
+
+    /// 予算が足りていれば、落ち着いた後は追い出しが止まる。
+    #[test]
+    fn a_sufficient_budget_settles_to_no_evictions() {
+        let mut b = TextureBudget::new(10 * full());
+        for _ in 0..10 {
+            for i in 0..3 {
+                b.admit(&format!("img-{i}"), full());
+            }
+            b.end_frame();
+        }
+        assert_eq!(b.evicted_last_frame(), 0, "予算が足りているのに追い出している");
     }
 
     /// 追い出しの結果が HashMap の反復順に左右されないこと。

--- a/crates/sabitori/src/declarative.rs
+++ b/crates/sabitori/src/declarative.rs
@@ -2187,6 +2187,12 @@ impl<A: DeclarativeApp> AppState<A> {
             scroll_states: scroll_info,
             tooltip: tooltip_info,
             drag: drag_info,
+            // 抱えているテクスチャの量。長時間起動の調べ物に要る (#47)。
+            textures: self
+                .image_renderer
+                .as_ref()
+                .map(|r| r.texture_stats())
+                .unwrap_or_default(),
             theme: self.app.theme(),
             presence: self.presence_animator.all_progress(),
             images: Some(self.image_ctx.clone()),
@@ -3504,6 +3510,7 @@ impl<A: DeclarativeApp> AppState<A> {
                 scroll_states: std::collections::HashMap::new(),
                 tooltip: None,
                 drag: None,
+                textures: Default::default(),
                 theme: self.app.theme(),
                 presence: std::collections::HashMap::new(),
                 images: Some(self.image_ctx.clone()),

--- a/crates/sabitori/src/scene_app.rs
+++ b/crates/sabitori/src/scene_app.rs
@@ -916,6 +916,12 @@ impl<A: SceneApp> ApplicationHandler for SceneAppState<A> {
                     }),
                     theme: self.app.theme(),
                     presence: self.presence_animator.all_progress(),
+                    // 抱えているテクスチャの量 (#47)。
+                    textures: self
+                        .image_renderer
+                        .as_ref()
+                        .map(|r| r.texture_stats())
+                        .unwrap_or_default(),
                     // SceneApp doesn't wire up an image runtime yet; callers
                     // can still use `image(key, data)` with their own cache.
                     images: None,


### PR DESCRIPTION
Closes #47, closes #50

## #47 — 抱えている量が見えなかった

`ViewContext::textures` に載せました。

```rust
ctx.textures.bytes                // いま占めている bytes
ctx.textures.count                // 枚数
ctx.textures.budget_bytes         // 上限
ctx.textures.evictions_total      // 起動からの累計追い出し数
ctx.textures.evicted_last_frame   // 直近 1 フレームの追い出し数
```

案 A（`ViewContext` に載せる）を採りました。案 B（`on_build` に渡す）はシグネチャ変更になり、統計を使わないアプリにも影響が出るためです。

低レベル側には `ImageRenderer::texture_stats()` を出しました。

### 追い出しの印がこの機能の要

報告の後半がいちばん効きます。予算が実際の working set より小さいと毎フレーム捨てて入れ直しますが、**絵は正しく出続けるので壊れて見えません**。静かに遅くなるだけです。

しかも #46 の追い出しは「今フレーム使われた鍵は捨てない」「収まらない時は超過を許す」と**安全側に倒れている**ので、超過が常態化していることは外に出さないと分かりません。ご指摘のとおりでした。

**`evicted_last_frame` が 0 に戻らなければ予算不足**、という読み方ができます。

## #50 — `replace_texture`

```rust
r.replace_texture(device, queue, key, rgba, w, h);
```

`drop_texture` → `ensure_texture` の 2 段でも同じことはできますが、報告のとおり**前半を書き忘れると古い絵が出続ける** — 壊れずに間違う形になります。意図をそのまま書ける口を足しました。

## テスト

`TextureBudget` に 3 本追加（計 15）。「静かに遅くなる」を数字で捕まえられるかがこの機能の要件なので、そこを固定しました。

| テスト | 見ていること |
|---|---|
| `evictions_are_counted` | 予算内なら 0、超えたら数が出る。`end_frame` を跨ぐまで前フレームの値のまま |
| `a_too_small_budget_keeps_evicting_every_frame` | **予算不足の状態で `evicted_last_frame` が 0 に戻らない** |
| `a_sufficient_budget_settles_to_no_evictions` | 足りていれば落ち着いて 0 になる（誤検知しない） |

`cargo test --workspace` → 38 スイート全パス。

## 破壊的変更ではありません

`ViewContext` にフィールドが増えるので、**構造体リテラルで直接組んでいる場合**はコンパイルが通らなくなります。ただしランタイム外での構築は想定されていない（リポジトリ内の 4 箇所のみ）ため、`!` は付けていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
