### PR TITLE
fix(declarative)!: lazy_render の既定を true にし、描画判定の穴を塞ぐ (#53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,25 @@
 
 ## [Unreleased]
 
-### Changed
+### Changed（破壊的）
 
-- **破壊的: `DeclarativeApp::lazy_render` の既定が `true` になった**
+- **`DeclarativeApp::lazy_render` の既定が `false` → `true` になった**
   ([#53](https://github.com/Mutafika/sabitori/issues/53))。
   入力もアニメーションも無いフレームは描かれなくなる。
 
   これまでの既定 (`false`) は、**何もしていない窓が 1 コアと GPU の一部を
   焼き続ける**という意味だった。刻みの既定が 8ms (≈120Hz)、`present_mode` が
   取れれば `Immediate` なので、「毎秒 120 回、無条件に全部描き直す」が既定の
-  構成になっていた。M2 Max の idle 実測で **CPU 69〜77% → 0.3%、GPU 45% → 0**。
+  構成になっていた。
+
+  idle 実測 (どちらも M2 Max / macOS):
+
+  | | CPU | GPU |
+  |---|---|---|
+  | 報告元のアプリ (#53) | 69〜77% → **0.3%** | 45% → **0** |
+  | `examples/declarative` (release・20 秒・窓は端末の裏) | 5.6% → **0.3%** | — |
+
+  絶対値の開きは、example が軽く窓が隠れていたぶん。向きと桁は一致している。
 
   仕組み自体は 0.5.x から在って、`lazy_render` を上書きすれば効いた。
   問題は opt-in だったこと — **repo 内の 12 本の example も含め、上書きして

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,55 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **破壊的: `DeclarativeApp::lazy_render` の既定が `true` になった**
+  ([#53](https://github.com/Mutafika/sabitori/issues/53))。
+  入力もアニメーションも無いフレームは描かれなくなる。
+
+  これまでの既定 (`false`) は、**何もしていない窓が 1 コアと GPU の一部を
+  焼き続ける**という意味だった。刻みの既定が 8ms (≈120Hz)、`present_mode` が
+  取れれば `Immediate` なので、「毎秒 120 回、無条件に全部描き直す」が既定の
+  構成になっていた。M2 Max の idle 実測で **CPU 69〜77% → 0.3%、GPU 45% → 0**。
+
+  仕組み自体は 0.5.x から在って、`lazy_render` を上書きすれば効いた。
+  問題は opt-in だったこと — **repo 内の 12 本の example も含め、上書きして
+  いる実装は 1 つも無かった**。誰も取らない opt-in は既定が間違っている。
+
+  **移行:** `tick(dt)` で絵を動かすなら
+  [`is_animating`](https://docs.rs/sabitori/latest/sabitori/trait.DeclarativeApp.html#method.is_animating)
+  を上書きする (この口は前から在り、example 6 本は既に書いていた)。一度きりの
+  変化なら `poll_dirty`。窓ごと降りたいなら `fn lazy_render(&self) -> bool { false }`
+  で 0.8.0 までと同じ挙動に戻る。
+
+  壊れ方が「操作したのに描き変わらない」という**目に見える形**になるのを取った。
+  今までの壊れ方 — 黙って 1 コアと GPU を焼く — は、探しに行かない限り誰も
+  気付かない。実際、過去に取った性能の実測値は全部その状態で取られていた。
+
+### Fixed
+
+- **`is_animating()` が lazy 判定から漏れていた**
+  ([#53](https://github.com/Mutafika/sabitori/issues/53))。
+  「`tick` が自前の状態を進めるなら上書きせよ」と doc に書いてある口を、
+  肝心の描画判定が見ていなかった。`lazy_render` を上書きしたアプリは、
+  正しく名乗っていても画面が止まる状態だった。
+
+- **presence (入退場) アニメーションが lazy 判定から漏れていた**。
+  `PresenceAnimator::has_animations()` は在ったのにランタイムが呼んでおらず、
+  要素が出かかった/消えかかった姿で固まりうる。`settle` の打ち切り判定にも
+  加えたので、Harness でも入退場が終わるまで回る。
+
+- **キャレット点滅が lazy で止まる問題**。位相を進めるのはランタイム側
+  (`advance`) なので、`view()` だけ書いたアプリには名乗る手段が無かった。
+  「登録済みテキスト欄がフォーカス中」をランタイムが自分で見るようにした。
+  収束しないので `settle` の打ち切り判定には**入れていない** — 入れると
+  フォーカス中のテストが毎回上限まで回る。
+
+### Notes
+
+- `SceneApp` 側には仕組みごと無い (`about_to_wait` が無条件に
+  `request_redraw`)。使う側から上書きする手段も無いので別途。
+
 ## [0.8.0] - 2026-08-22
 
 報告された壊れ方を 6 件まとめて直した版。

--- a/README.ja.md
+++ b/README.ja.md
@@ -78,7 +78,7 @@ div().click(ctx, format!("row-{i}"), move |app: &mut App| app.selected = Some(i)
 
 古い書き方 —`.id("save")` と `fn on_click(&mut self, id: &str)` の文字列マッチ— も動きますし、動的に振り分けたいときのために残してあります。ただし**どちらの文字列を打ち間違えてもコンパイルは通り、黙って何も起きません**。`click` を使ってください。
 
-## よく間違える 4 つ
+## よく間違える 5 つ
 
 この 4 つが他の全部を合わせたより多いです。それぞれ正解は 1 つだけ。
 
@@ -179,6 +179,28 @@ assert_eq!(h.app().saved.as_deref(), Some("hello"));
 ```
 
 **`frame()` は時間を進めません。** 慣性スクロール・`scroll_intents`・style アニメーションなど、ばねで動くものは `tick(dt)` か `settle()` が要ります。
+
+### 5. `tick` で絵を動かしているのに名乗らない
+
+**`tick(dt)` が画面を動かすなら `is_animating` を上書きします。**
+
+```rust
+fn is_animating(&self) -> bool { true }   // 粒子・スピナー・時計
+fn tick(&mut self, dt: f32) { self.t += dt; }
+```
+
+ランタイムは、誰も要求していないフレームを描きません。自分が持っている
+アニメーター — スクロールのばね、style、presence、ドラッグ、tooltip の遅延、
+そして組み込み `text_input` のキャレット — は見えますが、**アプリの状態は
+見えません**。名乗らずに `tick` で粒子を動かすと、**次の入力が来るまで画面が
+止まります**。
+
+一度きりの変化 (ワーカースレッドが終わった、toast の時間が切れた) は
+`poll_dirty` の方です。毎 tick に 1 回問われ、読むと下ります。
+
+`lazy_render` に `false` を返すと窓ごと降りて、無条件に描き続けます。0.8.0 まで
+の既定がこれで、idle の窓で 1 コアと GPU の一部を焼きます。まず `is_animating`
+を検討してください。
 
 ## レイアウト
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ div().click(ctx, format!("row-{i}"), move |app: &mut App| app.selected = Some(i)
 
 The older form — `.id("save")` plus a `fn on_click(&mut self, id: &str)` that matches on strings — still works and is still there for dynamic dispatch. But a typo in either string compiles fine and silently does nothing, so prefer `click`.
 
-## The four things people get wrong
+## The five things people get wrong
 
 These come up more than everything else combined. Each has exactly one correct form.
 
@@ -179,6 +179,27 @@ assert_eq!(h.app().saved.as_deref(), Some("hello"));
 ```
 
 `frame()` does not advance time. Anything spring-driven — momentum scroll, `scroll_intents`, style animation — needs `tick(dt)` or `settle()`.
+
+### 5. Animating in `tick` without saying so
+
+**If `tick(dt)` moves what is on screen, override `is_animating`.**
+
+```rust
+fn is_animating(&self) -> bool { true }   // particles, spinners, a clock
+fn tick(&mut self, dt: f32) { self.t += dt; }
+```
+
+The runtime does not redraw a frame that nothing asked for. It sees its own
+animators — scroll springs, style, presence, drag, tooltip delay, and the caret
+of a built-in `text_input` — but it cannot see your state. Move a particle in
+`tick` without saying so and **the screen stops until the next input event.**
+
+For a one-off change (a worker thread finished, a toast expired) use
+`poll_dirty` instead — it is asked once per tick and clears when read.
+
+Returning `false` from `lazy_render` opts the whole window out and redraws
+unconditionally. That was the default through 0.8.0; it costs roughly a core
+and a slice of the GPU on an idle window, so reach for `is_animating` first.
 
 ## Layout
 

--- a/crates/sabitori/src/declarative.rs
+++ b/crates/sabitori/src/declarative.rs
@@ -135,7 +135,28 @@ pub struct UiCapture {
     pub wants_keyboard: bool,
 }
 
-/// `'static` を要求するのは、 `Element::click` で登録されたハンドラが
+/// アプリ本体。 `view()` だけ実装すれば動く。
+///
+/// # 描かれないフレームがある
+///
+/// ランタイムは**誰も要求していないフレームを描かない**
+/// ([`lazy_render`](Self::lazy_render) の既定は `true`)。 自前のアニメーターは
+/// 見えているので、 スクロールのばね・style・presence・ドラッグ・tooltip の
+/// 遅延・組み込み `text_input` のキャレット点滅は放っておいて動く。
+///
+/// **見えないのはアプリの状態**。 [`tick`](Self::tick) で絵を動かすなら
+/// [`is_animating`](Self::is_animating) を上書きすること — 名乗らないと、
+/// 次の入力が来るまで画面が止まる。 一度きりの変化なら
+/// [`poll_dirty`](Self::poll_dirty)。
+///
+/// ```ignore
+/// fn is_animating(&self) -> bool { true }        // 粒子・スピナー・時計
+/// fn tick(&mut self, dt: f32) { self.t += dt; }
+/// ```
+///
+/// # `'static` について
+///
+/// 要求するのは、 `Element::click` で登録されたハンドラが
 /// `&mut dyn Any` 経由でアプリ本体に降りるため。 アプリはランタイムが所有して
 /// プロセス寿命まで持つので、 実質的な制約にはならない。
 pub trait DeclarativeApp: 'static {
@@ -310,11 +331,15 @@ pub trait DeclarativeApp: 'static {
     /// Called every frame with delta time. Use for animation ticking.
     fn tick(&mut self, _dt: f32) {}
 
-    /// Whether the app currently has its own animations running.
-    /// Return `true` to force the runtime into continuous-redraw mode.
-    /// Default `false` lets the runtime drop to its idle 1Hz heartbeat
-    /// when no built-in animator (scroll, tooltip, presence, style, drag)
-    /// is active. Override if your `tick(dt)` is advancing custom state.
+    /// アプリ自身のアニメーションが動いているか。
+    ///
+    /// **`tick(dt)` で絵を動かすなら上書きすること。** ランタイムが持つ
+    /// アニメーター (スクロール / スタイル / presence / ドラッグ / tooltip) は
+    /// ランタイムが自分で見るが、アプリの状態は見えない。既定の
+    /// [`lazy_render`](Self::lazy_render) は `true` なので、ここで名乗らないと
+    /// **入力が無いあいだ画面が止まる**。
+    ///
+    /// 一度きりの変化なら [`poll_dirty`](Self::poll_dirty) の方。
     fn is_animating(&self) -> bool { false }
 
     /// Element ids whose layout position should be reported back in
@@ -447,20 +472,36 @@ pub trait DeclarativeApp: 'static {
     /// The theme is available in `view()` via `ctx.theme`.
     fn theme(&self) -> sabitori_core::AppTheme { sabitori_core::AppTheme::default() }
 
-    /// Opt into lazy rendering: skip redraws when nothing is animating
-    /// and no input has occurred. Default `false` keeps the original
-    /// 60fps redraw loop for compatibility. When `true`, the runtime
-    /// only requests a redraw if input arrived, an animation is running,
-    /// or the app reports state changes via `poll_dirty`. Idle CPU drops
-    /// from "view+layout+GPU every 16ms" to ~0.
-    fn lazy_render(&self) -> bool { false }
+    /// 何も変わっていないフレームを描かない (既定 `true`)。
+    ///
+    /// `false` を返すと、入力もアニメーションも無い idle の窓が
+    /// [`target_frame_interval`](Self::target_frame_interval) ごとに
+    /// view の構築・レイアウト・GPU の提示を回し続ける。既定の 8ms と
+    /// `present_mode: Immediate` の組では **1 コアと GPU の一部を焼き続ける**
+    /// ([#53](https://github.com/Mutafika/sabitori/issues/53))。
+    ///
+    /// `true` のとき、ランタイムが redraw を出すのは次のいずれか:
+    ///
+    /// - 入力・フォーカス・リサイズ・IME・ドロップ等のイベントが来た
+    /// - ランタイム側のアニメーションが動いている
+    ///   (スクロールのばね / スタイル / presence / ドラッグ / tooltip の遅延 /
+    ///   **登録済みテキスト欄のキャレット点滅**)
+    /// - アプリが [`is_animating`](Self::is_animating) で `true` を返した
+    /// - アプリが [`poll_dirty`](Self::poll_dirty) で `true` を返した
+    ///
+    /// **`tick` で自前に絵を動かすなら [`is_animating`](Self::is_animating) を
+    /// 上書きすること。** 書かないと画面が止まる — ランタイムにはアプリの状態が
+    /// 変わったかどうかを知る手段が無い。
+    fn lazy_render(&self) -> bool { true }
 
-    /// Polled at the end of each tick (lazy mode only). Return `true` if
-    /// `tick` mutated visual state and the next frame should be redrawn.
-    /// Default `false` — input-driven UIs need not implement this since
-    /// input events already invalidate the frame; override only when your
-    /// `tick` drains async results that change what's on screen (e.g.
-    /// channels from worker threads, completion signals).
+    /// 毎 tick の最後に問われる。`tick` が絵を変えたなら `true`。
+    ///
+    /// **一度きりの変化**のための口。連続して動き続けるものは
+    /// [`is_animating`](Self::is_animating) の方を上書きする。
+    ///
+    /// 既定 `false` — 入力で動く UI は書かなくてよい (イベント自体がフレームを
+    /// 無効化する)。上書きするのは、`tick` がワーカースレッドのチャンネルを
+    /// 汲む・タイマの満了を拾う等、**外から来た変化**を反映するとき。
     fn poll_dirty(&mut self) -> bool { false }
 
     /// Target tick + redraw cadence. Default 8ms (≈120Hz) so ProMotion
@@ -1741,22 +1782,19 @@ impl<A: DeclarativeApp> ApplicationHandler for AppState<A> {
         // Layout / focus may have changed since the last pointer event —
         // keep the capture snapshot current once per tick.
         self.push_ui_capture();
-        let app_dirty = self.app.poll_dirty();
-        // Scroll spring / fling keeps animating after the user lets go of the
-        // wheel. Without this check, lazy_render parks the loop and the
-        // momentum scroll stutters or freezes mid-flight.
-        let scroll_animating = self.scroll_states.values().any(|sv| sv.is_animating());
-        let any_anim = self.style_animator.is_animating()
-            || self.drag_manager.is_active()
-            || scroll_animating
-            // tooltip の hover-delay / fade 中は tick を回し続ける。無いと lazy_render が
-            // loop を park して delay タイマが止まり、マウスを動かすまで tooltip が出ない。
-            || self.tooltip_state.is_pending();
-        let must_draw = !self.app.lazy_render()
-            || self.dirty
-            || app_dirty
-            || any_anim
-            || self.atlas_recover_pending;
+        // 判定そのものは [`DrawGate`] が持つ — 材料を集めるのがここ、
+        // 決めるのは向こう。 ヘッドレスに試せる形にしてある (#53)。
+        let must_draw = DrawGate {
+            lazy: self.app.lazy_render(),
+            dirty: self.dirty,
+            // `poll_dirty` は「問うと下りる」ので 1 フレームに 1 回だけ呼ぶ。
+            app_dirty: self.app.poll_dirty(),
+            app_animating: self.app.is_animating(),
+            runtime_animating: self.runtime_animating(),
+            caret_blinking: self.caret_blinking(),
+            atlas_recover_pending: self.atlas_recover_pending,
+        }
+        .must_draw();
 
         if must_draw {
             if let Some(w) = self.window.as_ref() {
@@ -1805,6 +1843,45 @@ pub(crate) struct FrameBuild {
     /// The overlay tree — app `overlay_view` plus the tooltip and drag ghost —
     /// when any of those produced content this frame.
     pub(crate) overlay_build: Option<BuildResult>,
+}
+
+/// 1 フレーム分の「描くべきか」の判断材料。
+///
+/// 集めるのは `about_to_wait`、 決めるのはここ。 副作用が無いので
+/// ヘッドレスに試せる — 既定を lazy にした以上、 **描かれない条件**の方が
+/// 本番の挙動を決めるので、 そこをテストで押さえられる形にしてある (#53)。
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct DrawGate {
+    /// アプリが [`DeclarativeApp::lazy_render`] で名乗った値。
+    /// `false` なら以下は全部無視して毎フレーム描く。
+    pub(crate) lazy: bool,
+    /// 前のフレーム以降に入力等のイベントが来た。
+    pub(crate) dirty: bool,
+    /// アプリが [`DeclarativeApp::poll_dirty`] で `true` を返した (一度きりの変化)。
+    pub(crate) app_dirty: bool,
+    /// アプリが [`DeclarativeApp::is_animating`] で `true` を返した (連続した動き)。
+    pub(crate) app_animating: bool,
+    /// ランタイム側のアニメーターのどれかが動いている
+    /// ([`AppState::runtime_animating`])。
+    pub(crate) runtime_animating: bool,
+    /// フォーカス中の登録済みテキスト欄がキャレットを点滅させている
+    /// ([`AppState::caret_blinking`])。
+    pub(crate) caret_blinking: bool,
+    /// グリフアトラスが溢れた直後。 次のフレームで flush + 再シェイプが要る。
+    pub(crate) atlas_recover_pending: bool,
+}
+
+impl DrawGate {
+    /// このフレームで redraw を出すべきか。
+    pub(crate) fn must_draw(self) -> bool {
+        !self.lazy
+            || self.dirty
+            || self.app_dirty
+            || self.app_animating
+            || self.runtime_animating
+            || self.caret_blinking
+            || self.atlas_recover_pending
+    }
 }
 
 /// What [`plan_extras`] decided to do with the live extra-window set.
@@ -2542,11 +2619,38 @@ impl<A: DeclarativeApp> AppState<A> {
     /// ランタイムかアプリのどこかがまだ動いているか。 [`Self::advance`] を
     /// 回し続けるべきかの判定で、 テストの「落ち着くまで待つ」もこれを見る。
     pub(crate) fn is_animating(&self) -> bool {
-        self.app.is_animating()
-            || self.scroll_states.values().any(|sv| sv.is_animating())
+        self.app.is_animating() || self.runtime_animating()
+    }
+
+    /// ランタイムが自分で持っているアニメーションのどれかが動いているか。
+    ///
+    /// **落ち着く (収束する) ものだけ**をここに入れる — `settle` がこれを見て
+    /// 打ち切りを決めるので、 永久に動き続けるもの (キャレット点滅) を混ぜると
+    /// 待ち切れなくなる。 そちらは [`Self::caret_blinking`]。
+    pub(crate) fn runtime_animating(&self) -> bool {
+        self.scroll_states.values().any(|sv| sv.is_animating())
             || self.style_animator.is_animating()
+            // 入退場 (presence) の最中。 見ていないと lazy_render が loop を
+            // park して、 要素が出かかった/消えかかった姿で固まる。
+            || self.presence_animator.has_animations()
             || self.drag_manager.is_active()
+            // tooltip の hover-delay / fade 中は tick を回し続ける。無いと lazy_render が
+            // loop を park して delay タイマが止まり、マウスを動かすまで tooltip が出ない。
             || self.tooltip_state.is_pending()
+    }
+
+    /// フォーカス中の登録済みテキスト欄がキャレットを点滅させているか。
+    ///
+    /// 点滅の位相を進めるのは [`Self::advance`] (ランタイム側) なので、
+    /// **アプリには名乗る手段が無い**。 ここで拾わないと、 既定の
+    /// `lazy_render` でキャレットの止まったテキスト欄になる (#53)。
+    ///
+    /// 収束しないので [`Self::is_animating`] には入れない — あちらは
+    /// `settle` の打ち切り判定。
+    pub(crate) fn caret_blinking(&self) -> bool {
+        self.focused_id
+            .as_deref()
+            .is_some_and(|id| self.managed_text_field(id).is_some())
     }
 
     pub(crate) fn press_primary(&mut self) {
@@ -4935,5 +5039,130 @@ mod extra_window_tests {
             }
         }
         assert!(!Plain.take_window_reconcile());
+    }
+}
+
+/// 「描くべきか」の判定 — 既定を lazy にした以上、 **描かれない条件**の方が
+/// 本番の挙動を決める ([#53](https://github.com/Mutafika/sabitori/issues/53))。
+#[cfg(test)]
+mod draw_gate_tests {
+    use super::*;
+    use crate::testing::Harness;
+    use sabitori_widgets::{text_input, TextInputState, TextInputStyle};
+
+    /// 何も起きていない lazy フレーム。 ここから 1 つずつ立てて見る。
+    fn idle() -> DrawGate {
+        DrawGate { lazy: true, ..DrawGate::default() }
+    }
+
+    #[test]
+    fn idle_lazy_frame_is_not_drawn() {
+        assert!(!idle().must_draw(), "何も起きていない lazy フレームは描かない");
+    }
+
+    /// `lazy_render` を切ったら、 他が全部静まっていても描く。
+    /// 0.8.0 までの既定の挙動で、 明示的な opt-out として残っている。
+    #[test]
+    fn opting_out_of_lazy_draws_unconditionally() {
+        assert!(DrawGate { lazy: false, ..DrawGate::default() }.must_draw());
+    }
+
+    /// 描く理由は 6 つあり、 **どれ 1 つでも欠けると画面が止まる**。
+    /// 表にして 1 本ずつ立て、 全部が単独で効くことを見る。
+    #[test]
+    fn every_reason_draws_on_its_own() {
+        let reasons: [(&str, fn(&mut DrawGate)); 6] = [
+            ("入力が来た", |g| g.dirty = true),
+            ("アプリが poll_dirty で名乗った", |g| g.app_dirty = true),
+            ("アプリが is_animating で名乗った", |g| g.app_animating = true),
+            ("ランタイムのアニメーターが動いている", |g| g.runtime_animating = true),
+            ("キャレットが点滅している", |g| g.caret_blinking = true),
+            ("アトラスの復帰待ち", |g| g.atlas_recover_pending = true),
+        ];
+        for (why, set) in reasons {
+            let mut g = idle();
+            set(&mut g);
+            assert!(g.must_draw(), "{why} のに描かれない");
+        }
+    }
+
+    fn style() -> TextInputStyle {
+        TextInputStyle {
+            bg: sabitori_core::Color::from_hex("#202020"),
+            border: sabitori_core::Color::from_hex("#404040"),
+            text: sabitori_core::Color::WHITE,
+            placeholder: sabitori_core::Color::from_hex("#808080"),
+            font_size: 14.0,
+            radius: 4.0,
+            padding: 8.0,
+            focus_border: None,
+            caret: None,
+            preedit: None,
+            selection: None,
+        }
+    }
+
+    /// `view()` しか実装していないアプリ。 既定が lazy になって最初に
+    /// 割を食う立場で、 テキスト欄をただ置いただけのもの。
+    struct BareField {
+        name: TextInputState,
+    }
+
+    impl DeclarativeApp for BareField {
+        fn view(&self, ctx: &ViewContext) -> Element {
+            text_input(ctx, "name", &self.name, &style())
+        }
+    }
+
+    fn bare() -> Harness<BareField> {
+        let mut h = Harness::new(BareField { name: TextInputState::new("名前") }, 400.0, 200.0);
+        h.frame();
+        h
+    }
+
+    /// **本題。** 組み込みのテキスト欄はキャレットが点滅していて、 位相を
+    /// 進めるのはランタイム側 (`advance`) — アプリには名乗る手段が無い。
+    /// ここを拾わないと、 `view()` だけ書いたアプリが「キャレットの止まった
+    /// テキスト欄」になる。
+    #[test]
+    fn focused_managed_field_keeps_the_frame_alive() {
+        let mut h = bare();
+        assert!(!h.state.caret_blinking(), "フォーカス前は点滅していない");
+
+        h.click("name");
+        assert_eq!(h.focused_id(), Some("name"));
+        assert!(h.state.caret_blinking(), "フォーカス中の欄はキャレットが点滅する");
+    }
+
+    /// フォーカスが外れたら止まる。 「点滅していることにして描き続ける」
+    /// のでは既定を lazy にした意味が無い。
+    #[test]
+    fn blurring_the_field_lets_the_loop_park_again() {
+        let mut h = bare();
+        h.click("name");
+        assert!(h.state.caret_blinking());
+
+        h.click_at(390.0, 190.0); // 欄の外
+        assert_eq!(h.focused_id(), None);
+        assert!(!h.state.caret_blinking(), "フォーカスが外れたら点滅も止まる");
+    }
+
+    /// 触っていないアプリは本当に静まっている。 ここが `true` に張り付くと
+    /// `settle` が毎回上限まで回り、 lazy の意味も無くなる。
+    #[test]
+    fn an_untouched_app_is_genuinely_idle() {
+        let h = bare();
+        assert!(!h.state.runtime_animating(), "何もしていないのにアニメーション扱い");
+        assert!(!h.state.caret_blinking());
+    }
+
+    /// キャレットは収束しないので `is_animating` (= `settle` の打ち切り判定)
+    /// には**入れない**。 入れるとフォーカス中のテスト全部が上限まで回る。
+    #[test]
+    fn caret_does_not_stall_settle() {
+        let mut h = bare();
+        h.click("name");
+        assert!(h.state.caret_blinking());
+        assert!(h.settle() < 120, "キャレット点滅で settle が待ち切れなくなっている");
     }
 }

--- a/crates/sabitori/src/testing.rs
+++ b/crates/sabitori/src/testing.rs
@@ -163,7 +163,9 @@ fn stub_line_of(content: &str, byte_offset: usize) -> (usize, &str) {
 ///
 /// 窓も wgpu デバイスも作らない。 モジュールの doc も参照。
 pub struct Harness<A: DeclarativeApp> {
-    state: AppState<A>,
+    /// クレート内のテストからランタイムの内部状態を直接見るために開けてある
+    /// (`declarative.rs` の `draw_gate_tests` 等)。 公開 API ではない。
+    pub(crate) state: AppState<A>,
     width: f32,
     height: f32,
 }

--- a/crates/sabitori/tests/readme_examples.rs
+++ b/crates/sabitori/tests/readme_examples.rs
@@ -272,7 +272,37 @@ assert_eq!(h.app().saved.as_deref(), Some("hello"));
     }
 }
 
-// ===== README [10] レイアウト =====
+// ===== README [10] tick で動かすなら名乗る =====
+mod animating_section {
+    use super::*;
+
+    /// README の 5 番目の落とし穴そのもの — `tick` が絵を動かすアプリ。
+    #[derive(Default)]
+    pub struct Spinner {
+        pub t: f32,
+    }
+
+    impl DeclarativeApp for Spinner {
+        fn view(&self, _ctx: &ViewContext) -> Element {
+            div().id("dot").w(Px(10.0)).h(Px(10.0))
+        }
+
+fn is_animating(&self) -> bool { true }   // particles, spinners, a clock
+fn tick(&mut self, dt: f32) { self.t += dt; }
+    }
+
+    /// 名乗ったアプリは `settle` が打ち切れない = 描き続ける側に居る。
+    /// README が「止まりません」と言っているのはこの状態。
+    #[test]
+    fn naming_yourself_animating_keeps_the_runtime_awake() {
+        let mut h = Harness::new(Spinner::default(), 200.0, 200.0);
+        h.frame();
+        assert_eq!(h.settle_for(3), 3, "is_animating が true なら落ち着かない");
+        assert!(h.app().t > 0.0, "tick で時間が進んでいる");
+    }
+}
+
+// ===== README [11] レイアウト =====
 mod layout_section {
     use super::*;
 
@@ -304,7 +334,7 @@ let sheet = grid()
     }
 }
 
-// ===== README [11] ウィジェット =====
+// ===== README [12] ウィジェット =====
 mod widget_section {
     use super::*;
 
@@ -342,7 +372,7 @@ div().flex_col().children([
     }
 }
 
-// ===== README [12] アクセシビリティ =====
+// ===== README [13] アクセシビリティ =====
 mod a11y_section {
     use super::*;
 

--- a/examples/filer.rs
+++ b/examples/filer.rs
@@ -317,6 +317,8 @@ struct FilerApp {
     window: Option<std::sync::Arc<winit::window::Window>>,
     // External file hover (drag from another window/app)
     hover_files: Vec<PathBuf>,
+    /// `tick` が絵を変えたか。 `poll_dirty` で汲んで下ろす。
+    tick_changed: bool,
     // Conflict resolution modal
     conflict_modal: Option<ConflictModal>,
     hover_mouse: (f32, f32),
@@ -369,6 +371,7 @@ impl FilerApp {
             toast: None,
             window: None,
             hover_files: Vec::new(),
+            tick_changed: false,
             conflict_modal: None,
             hover_mouse: (0.0, 0.0),
         }
@@ -1205,16 +1208,36 @@ impl DeclarativeApp for FilerApp {
         None
     }
 
+    /// 外部ファイルをドラッグで持ってきている間だけ、 毎フレーム描き直す。
+    /// OS のドラッグ中は `CursorMoved` が来ないので `tick` でマウスを追って
+    /// おり、 入力イベントが 1 つも無いまま絵が動く — 既定の `lazy_render`
+    /// はそれを知る手立てが無いので、 ここで名乗る。
+    fn is_animating(&self) -> bool {
+        !self.hover_files.is_empty()
+    }
+
+    /// toast と古いドラッグの掃除は「時計が来たら 1 回」。 連続した動きでは
+    /// ないので `is_animating` ではなくこちら。
+    fn poll_dirty(&mut self) -> bool {
+        std::mem::take(&mut self.tick_changed)
+    }
+
     fn tick(&mut self, _dt: f32) {
         // スクロールのばねはランタイムが回す (`.scroll(id)` に付けた時点で
         // 位置も速度もランタイムの持ち物)。 ここで tick する必要は無い。
         // Clear toast after 2 seconds
         if let Some((_, time)) = &self.toast {
-            if time.elapsed().as_secs_f32() > 2.0 { self.toast = None; }
+            if time.elapsed().as_secs_f32() > 2.0 {
+                self.toast = None;
+                self.tick_changed = true;
+            }
         }
         // Clear stale drag after 5 seconds
         if let Some(ref drag) = self.drag {
-            if drag.created.elapsed().as_secs() > 5 { self.drag = None; }
+            if drag.created.elapsed().as_secs() > 5 {
+                self.drag = None;
+                self.tick_changed = true;
+            }
         }
         // Poll mouse position during external file hover (OS drag doesn't send CursorMoved)
         #[cfg(target_os = "macos")]

--- a/examples/tui_gallery.rs
+++ b/examples/tui_gallery.rs
@@ -1872,6 +1872,13 @@ impl DeclarativeApp for Gallery {
         ]
     }
 
+    /// スピナー・グラデーション・波・パルス・タイプライタが常時回っていて、
+    /// 入力が 1 つも無くても絵が変わり続ける。 既定の `lazy_render` に対して
+    /// 「自分は動いている」と名乗る側。
+    fn is_animating(&self) -> bool {
+        true
+    }
+
     fn tick(&mut self, dt: f32) {
         if !self.splash_done && self.elapsed() >= SPLASH_DURATION {
             self.splash_done = true;


### PR DESCRIPTION
Closes #53

## 何が起きていたか

何もしていない窓が **1 コアと GPU の一部を焼き続けて**いた。刻みの既定が 8ms (≈120Hz)、`present_mode` は取れれば `Immediate` なので、既定の構成は「毎秒 120 回、無条件に全部描き直す」だった。

仕組み自体は 0.5.x から在って、`lazy_render` を上書きすれば効いた。**問題は opt-in だったこと** — repo 内の example 12 本を含め、上書きしている実装は 1 つも無かった。誰も取らない opt-in は既定が間違っている。

## 変更

### 破壊的

`DeclarativeApp::lazy_render` の既定が `false` → **`true`**。入力もアニメーションも無いフレームは描かれなくなる。

### 判定側の穴を 3 つ

既定を lazy にする前提だと、どれも「画面が止まる」に化ける:

| 穴 | 中身 |
|---|---|
| `is_animating()` が `must_draw` から漏れていた | 「`tick` が自前の状態を進めるなら上書きせよ」と doc に書いてある口を、肝心の描画判定が見ていなかった。`lazy_render` を上書きしたアプリは**正しく名乗っていても止まる**状態だった |
| presence (入退場) が漏れていた | `has_animations()` は在ったのに呼んでおらず、要素が出かかった姿で固まりうる。`settle` の打ち切り判定にも加えた |
| キャレット点滅が止まる | 位相を進めるのはランタイム側 (`advance`) なので、`view()` だけ書いたアプリには名乗る手段が無い。「登録済みテキスト欄がフォーカス中」をランタイムが自分で見るようにした |

キャレットは収束しないので `settle` の打ち切り判定には**入れていない** — 入れるとフォーカス中のテストが毎回上限まで回る。

### 判定を `DrawGate` に切り出した

材料を集めるのが `about_to_wait`、決めるのが `DrawGate::must_draw`。既定を lazy にした以上、**描かれない条件**の方が本番の挙動を決めるので、そこをヘッドレスに押さえられる形にした (#28 と同じ理由)。

## 実測

M2 Max / release / `examples/declarative` / idle 20 秒 / 窓は端末の裏:

| | %cpu 平均 | cpu time (20秒) |
|---|---|---|
| `lazy=false` (0.8.0 までの既定) | 5.6 | 1.19s |
| `lazy=true` (本 PR) | 0.3 | 0.06s |

約 20 倍。イシューの 69→0.3% はもっと重いアプリの、可視の窓での数字。

## 移行

`tick(dt)` で絵を動かすなら `is_animating` を上書きする（この口は前から在り、**example 6 本は既に書いていた**）。一度きりの変化なら `poll_dirty`。窓ごと降りたいなら `fn lazy_render(&self) -> bool { false }` で 0.8.0 までと同じ。

repo 内で移行が要ったのは 2 本だけ:

- `tui_gallery` — スピナー等が常時回る → `is_animating() -> true`
- `filer` — toast / 古いドラッグの掃除は一度きり → `poll_dirty`、外部ファイルの hover 中だけ `is_animating`

## テスト

- `DrawGate` の判定表 — 描く理由 6 つが**単独で効く**ことを 1 本ずつ
- `view()` しか実装していないアプリ + `text_input` で、フォーカス中はキャレットが frame を生かし、外れると止まること
- キャレットで `settle` が待ち切れなくならないこと
- 触っていないアプリが本当に idle であること
- README の新節を逐語で回す (`readme_examples`)

38 スイート全パス。

## 別件

`SceneApp` 側には仕組みごと無い (`about_to_wait` が無条件に `request_redraw`)。使う側から上書きする手段も無いので、こちらは手つかず。

🤖 Generated with [Claude Code](https://claude.com/claude-code)