### PR TITLE
fix(core): Element の太いフィールドを Box 化 — wasm32 の 1MB スタックを view() が食い潰す (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **wasm32 で view() 構築が既定スタック (1MB) を食い潰して即死する**
+  ([#56](https://github.com/Mutafika/sabitori/issues/56)) — `Element` が
+  `ElementStyle` (536B) と hover/active の `StateStyle` (220B×2) をインラインで抱えて
+  **1224B** あり、ビルダー式の入れ子 1 段ごとにそれがスタックへ値渡しで積まれる。
+  デバッグビルドの wasm はテンポラリのスロットを再利用しないため、大きめの `view()`
+  だけで 1MB を超え、生の `RuntimeError: memory access out of bounds` で落ちていた
+  (panic を経由しないので原因に辿り着きにくい。native はスタック 8MB で無症状)。
+
+  太い 3 フィールドを Box 化して `Element` を **272B** に削減
+  (`style: Box<ElementStyle>`、`hover_style`/`active_style: Option<Box<StateStyle>>`)。
+  読み手は auto-deref でそのまま、書き手も builder API 経由なら変更なし。
+  フィールドを直接組む消費者だけ `Box::new` が要る (実質 API 変更なし扱いの patch)。
+  bamiri-plateau の実 view (起動即死していたもの) が既定 1MB スタックで
+  全操作 (picker/text_input 打鍵込み) 動作することを headless Chrome で確認。
+  `size_probe` テストで上限 320B を張り、無音の再肥大を止める。
+
+  副収穫として、ノード 1 個あたりのコピーが 1/4.5 になるので native の view 構築も
+  軽くなる (毎フレーム数千ノード × memcpy 1.2KB → 272B)。
+
 ## [0.11.0] - 2026-08-27
 
 **窓を起こしても誰の邪魔もしない版。**

--- a/crates/sabitori-core/src/element.rs
+++ b/crates/sabitori-core/src/element.rs
@@ -935,7 +935,11 @@ impl StateStyle {
 /// A declarative UI element. Constructed via `div()`, `text()`, or `button()`.
 pub struct Element {
     pub kind: ElementKind,
-    pub style: ElementStyle,
+    /// スタイルは Box で持つ。ElementStyle は 536B あり、インラインだと Element が
+    /// 1.2KB 超になって builder 式の入れ子 1 段ごとにそれがスタックへ積まれる —
+    /// wasm32 の既定スタック 1MB を view() 構築だけで食い潰していた (#56)。
+    /// 読み手は auto-deref でそのまま `el.style.x` と書ける。
+    pub style: Box<ElementStyle>,
     pub children: Vec<Element>,
     /// Unique identifier for event dispatch (click/hover).
     pub id: Option<String>,
@@ -954,10 +958,10 @@ pub struct Element {
     pub label: Option<String>,
     /// 見出しの階層 (1 が最上位)。 [`Role::Heading`] のときだけ意味がある。
     pub heading_level: Option<u8>,
-    /// Style overrides when hovered.
-    pub hover_style: Option<StateStyle>,
+    /// Style overrides when hovered. Box なのは style と同じ理由 (#56、220B×2)。
+    pub hover_style: Option<Box<StateStyle>>,
     /// Style overrides when pressed/active.
-    pub active_style: Option<StateStyle>,
+    pub active_style: Option<Box<StateStyle>>,
     /// Transition declarations.
     pub transitions: Vec<Transition>,
     /// When true, this element (and all its children) renders on the overlay
@@ -1181,7 +1185,7 @@ pub fn fold_state_style(style: &mut ElementStyle, s: &StateStyle, animated: bool
 pub fn div() -> Element {
     Element {
         kind: ElementKind::Div,
-        style: ElementStyle::default(),
+        style: Box::default(),
         children: Vec::new(),
         id: None,
         on_click: None,
@@ -1219,7 +1223,7 @@ pub fn grid() -> Element {
 pub fn text(content: impl Into<String>) -> Element {
     Element {
         kind: ElementKind::Text { content: content.into() },
-        style: ElementStyle::default(),
+        style: Box::default(),
         children: Vec::new(),
         id: None,
         on_click: None,
@@ -1254,7 +1258,7 @@ pub fn polyline() -> Element {
             width: 1.5,
             color: Color::TRANSPARENT,
         }),
-        style: ElementStyle::default(),
+        style: Box::default(),
         children: Vec::new(),
         id: None,
         on_click: None,
@@ -1296,7 +1300,7 @@ pub fn arc() -> Element {
             fill_color: Color::TRANSPARENT,
             track_color: Color::TRANSPARENT,
         }),
-        style: ElementStyle::default(),
+        style: Box::default(),
         children: Vec::new(),
         id: None,
         on_click: None,
@@ -1322,7 +1326,7 @@ pub fn arc() -> Element {
 pub fn image(key: impl Into<String>, data: ImageData) -> Element {
     Element {
         kind: ElementKind::Image { key: key.into(), data },
-        style: ElementStyle::default(),
+        style: Box::default(),
         children: Vec::new(),
         id: None,
         on_click: None,
@@ -1346,7 +1350,7 @@ pub fn image(key: impl Into<String>, data: ImageData) -> Element {
 
 /// Create a button element with default interactive styles.
 pub fn button(label: impl Into<String>) -> Element {
-    let mut style = ElementStyle::default();
+    let mut style = Box::<ElementStyle>::default();
     style.flex_direction = FlexDirection::Row;
     style.align_items = AlignItems::Center;
     style.justify_content = JustifyContent::Center;
@@ -1375,8 +1379,8 @@ pub fn button(label: impl Into<String>) -> Element {
         //
         // Callers who want something else just override with `.hover()` /
         // `.active()`; those replace these outright.
-        hover_style: Some(StateStyle { scale: Some(1.02), ..StateStyle::default() }),
-        active_style: Some(StateStyle { scale: Some(0.96), ..StateStyle::default() }),
+        hover_style: Some(Box::new(StateStyle { scale: Some(1.02), ..StateStyle::default() })),
+        active_style: Some(Box::new(StateStyle { scale: Some(0.96), ..StateStyle::default() })),
         transitions: vec![Transition {
             property: TransitionProperty::All,
             kind: TransitionKind::default(),
@@ -1561,7 +1565,7 @@ impl Element {
     }
 
     /// Subtle glow (30% alpha, 8px blur).
-    pub fn glow_sm(mut self, color: Color) -> Self {
+    pub fn glow_sm(self, color: Color) -> Self {
         self.glow(color.with_alpha(0.3), 8.0)
     }
 
@@ -2482,7 +2486,7 @@ impl Element {
     /// div().bg(surface).hover(|s| s.bg(surface_hover).scale(1.02))
     /// ```
     pub fn hover(mut self, f: impl FnOnce(StateStyle) -> StateStyle) -> Self {
-        self.hover_style = Some(f(StateStyle::default()));
+        self.hover_style = Some(Box::new(f(StateStyle::default())));
         self
     }
 
@@ -2491,7 +2495,7 @@ impl Element {
     /// div().bg(surface).active(|s| s.bg(surface_active).scale(0.98))
     /// ```
     pub fn active(mut self, f: impl FnOnce(StateStyle) -> StateStyle) -> Self {
-        self.active_style = Some(f(StateStyle::default()));
+        self.active_style = Some(Box::new(f(StateStyle::default())));
         self
     }
 

--- a/crates/sabitori-core/tests/size_probe.rs
+++ b/crates/sabitori-core/tests/size_probe.rs
@@ -1,0 +1,21 @@
+//! Element のサイズ回帰テスト (#56)。
+//!
+//! Element はビルダー式の入れ子 1 段ごとにスタックへ値渡しで積まれる。かつて
+//! ElementStyle (536B) と hover/active の StateStyle (220B×2) をインラインで抱えて
+//! 1224B あり、wasm32 の既定スタック 1MB を view() 構築だけで食い潰して
+//! 「RuntimeError: memory access out of bounds」で即死していた (native は 8MB で無症状)。
+//! 太いフィールドを Box 化して 272B に落とした。ここで上限を張り、フィールド追加で
+//! 音もなく太るのを止める。
+
+use sabitori_core::element::Element;
+
+#[test]
+fn element_stays_small_enough_for_wasm_stacks() {
+    let size = std::mem::size_of::<Element>();
+    println!("size_of::<Element>() = {size} B");
+    assert!(
+        size <= 320,
+        "Element が {size}B に太った (上限 320B)。インラインの大きいフィールドは \
+         Box に置く (#56 — wasm32 の 1MB スタックを view() 構築が食い潰す)"
+    );
+}


### PR DESCRIPTION
#56 の修正。`Element` が `ElementStyle` (536B) + hover/active の `StateStyle` (220B×2) をインラインで抱えて **1224B** あり、builder 式の入れ子 1 段ごとに値渡しでスタックへ積まれる。デバッグビルドの wasm はテンポラリのスロットを再利用しないため、大きめの `view()` だけで wasm32 既定スタック (1MB) を超え、生の `RuntimeError: memory access out of bounds` で即死していた (panic を経由しない = 原因に辿り着きにくい。native は 8MB で無症状)。

## 変更

- `style: Box<ElementStyle>` / `hover_style`・`active_style: Option<Box<StateStyle>>` → `Element` は **272B (1/4.5)**。
- 読み手は auto-deref で無変更。書き手も builder API 経由なら無変更 (フィールドを直接組む箇所のみ `Box::new`、リポジトリ内は button 既定スタイル等 8 箇所)。
- `size_probe` テストで **上限 320B をアサート** — フィールド追加で無音の再肥大が起きたら CI で止まる。
- CHANGELOG は [Unreleased] の Fixed に記載済み (patch リリース想定)。

## 実証

- bamiri-plateau の実 view (v0.11.0 で起動即死していたもの) を **既定 1MB スタック**の wasm でビルドし、headless Chrome で OOB 25 件 → **0 件**。picker 樹状 + text_input 打鍵絞り込みまで全操作動作。
- 描画への影響ゼロ: pin (v0.11.0) と本修正の wasm スクショが **AE=0 の完全ピクセル一致** (SwiftShader = 決定的レンダラで比較)。
- `cargo test --workspace` 緑 (全 crate)、消費側 (bamiri-plateau) の native テスト + スクショも緑。

副収穫: ノード 1 個あたりの move が 1.2KB → 272B になるので、native の view 構築 (毎フレーム数千ノード) も軽くなる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmM15JdZZSv8J5KCSgZWWs
